### PR TITLE
More FreeBSD support

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -325,6 +325,7 @@ where
 	}
 	Ok(())
 }
+
 /// Loops sendfile till len elapsed or error
 pub fn copy_sendfile<O: AsRawFd, I: AsRawFd>(in_: &I, out: &O, len: u64) -> Result<(), nix::Error> {
 	#[cfg(any(target_os = "android", target_os = "linux"))]
@@ -360,7 +361,30 @@ pub fn copy_sendfile<O: AsRawFd, I: AsRawFd>(in_: &I, out: &O, len: u64) -> Resu
 		}
 		Ok(())
 	}
+	#[cfg(target_os = "freebsd")]
+	{
+		use nix::sys::sendfile;
+		let mut offset = 0;
+		while offset != len {
+			let (result, n) = sendfile::sendfile(
+				in_.as_raw_fd(),
+				out.as_raw_fd(),
+				0,
+				Some((len - offset) as usize),
+				None,
+				None,
+				sendfile::SfFlags::empty(),
+				0,
+			);
+			result?;
+			assert!(0 < n && n as u64 <= len - offset);
+			offset += n as u64;
+		}
+		Ok(())
+
+	}
 }
+
 /// Loops splice till len elapsed or error
 #[cfg(any(target_os = "android", target_os = "linux"))]
 pub fn copy_splice<O: AsRawFd, I: AsRawFd>(in_: &I, out: &O, len: u64) -> Result<(), nix::Error> {

--- a/src/file.rs
+++ b/src/file.rs
@@ -167,7 +167,11 @@ pub fn memfd_create(name: &CStr, cloexec: bool) -> Result<Fd, nix::Error> {
 		#[cfg(target_os = "freebsd")]
 		{
 			let _ = name;
-			let flags = if cloexec { fcntl::OFlag::O_RDWR | fcntl::OFlag::O_CLOEXEC } else { fcntl::OFlag::O_RDWR };
+			let flags = if cloexec {
+				fcntl::OFlag::O_RDWR | fcntl::OFlag::O_CLOEXEC
+			} else {
+				fcntl::OFlag::O_RDWR
+			};
 			errno::Errno::result(unsafe {
 				libc::shm_open(libc::SHM_ANON, flags.bits(), stat::Mode::S_IRWXU.bits())
 			})
@@ -384,7 +388,6 @@ pub fn copy_sendfile<O: AsRawFd, I: AsRawFd>(in_: &I, out: &O, len: u64) -> Resu
 			offset += n as u64;
 		}
 		Ok(())
-
 	}
 }
 

--- a/src/valgrind.rs
+++ b/src/valgrind.rs
@@ -28,7 +28,7 @@ pub fn valgrind_start_fd() -> Fd {
 	let rlim = getrlimit(libc::RLIMIT_NOFILE).unwrap();
 	let valgrind_start_fd = rlim.rlim_max;
 	assert!(
-		valgrind_start_fd < Fd::max_value() as u64,
+		valgrind_start_fd < Fd::max_value() as _,
 		"{:?}",
 		valgrind_start_fd
 	);

--- a/src/valgrind.rs
+++ b/src/valgrind.rs
@@ -3,7 +3,7 @@
 use super::*;
 #[cfg(unix)]
 use nix::{errno, libc};
-use std::convert::{TryFrom, TryInto};
+use std::convert::TryInto;
 #[cfg(unix)]
 use std::mem;
 


### PR DESCRIPTION
Found this while browsing [unix-apis on cargo](https://crates.io/categories/os::unix-apis), immediately went to check for anonymous shared memory, ended up doing some more stuff :)

I actually made [a crate for that](https://github.com/myfreeweb/shmemfdrs) a while ago… that one does `ftruncate` (allocating some length of memory) in one step. This crate probably should include a convenience wrapper that does the same.

Also, what do you think about adding [errno](https://github.com/lfairy/rust-errno) and [pdfork](https://github.com/myfreeweb/pdfork) functionality here? I like the idea of one single portability crate instead of a hundred mini-crates.