### PR TITLE
Bump libc and put valgrind_request behind "nightly" feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ addons:
 
 env:
   global:
-    - RUST_LINT_VERSION=nightly-2019-01-09
+    - RUST_LINT_VERSION=nightly-2019-01-18
 
 matrix:
   include:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,14 +24,18 @@ travis-ci = { repository = "alecmocatta/palaver" }
 
 maintenance = { status = "actively-developed" }
 
+[features]
+default = ["nightly"]
+nightly = ["valgrind_request"]
+
 [dependencies]
-valgrind_request = "1.1"
+valgrind_request = { version = "1.1", optional = true }
 void = "1.0"
 bitflags = "1.0"
 lazy_static = "1.0"
 
 [target.'cfg(unix)'.dependencies]
-libc = "=0.2.46"
+libc = "0.2.47"
 nix = "0.11"
 
 [target.'cfg(windows)'.dependencies]
@@ -42,9 +46,6 @@ mach = "0.2"
 
 [target.'cfg(any(target_os = "android", target_os = "linux"))'.dependencies]
 procinfo = "0.4"
-
-[replace]
-"libc:0.2.46" = { git = "https://github.com/alecmocatta/libc" }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ valgrind_request = { version = "1.1", optional = true }
 void = "1.0"
 bitflags = "1.0"
 lazy_static = "1.0"
+try_from = "0.3"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.47"

--- a/src/file.rs
+++ b/src/file.rs
@@ -5,14 +5,6 @@ use super::*;
 use ext::ToHex;
 #[cfg(unix)]
 use nix::{errno, fcntl, sys::stat, unistd};
-#[cfg(any(
-	target_os = "linux",
-	target_os = "android",
-	target_os = "macos",
-	target_os = "ios",
-	target_os = "freebsd"
-))]
-use std::convert::TryInto;
 #[cfg(unix)]
 use std::{
 	ffi::{CStr, CString, OsString}, fs, mem, os::unix::ffi::OsStringExt, os::unix::io::AsRawFd
@@ -20,6 +12,14 @@ use std::{
 use std::{
 	fmt, io::{self, Read, Write}, path
 };
+#[cfg(any(
+	target_os = "linux",
+	target_os = "android",
+	target_os = "macos",
+	target_os = "ios",
+	target_os = "freebsd"
+))]
+use try_from::TryInto;
 
 /// Maps file descriptors [(from,to)]
 #[cfg(unix)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 //!
 //! `palaver` = "Platform Abstraction Layer" + pa·lav·er *n.* prolonged and tedious fuss.
 
-#![feature(try_from, uniform_paths)]
+#![feature(try_from)]
 #![doc(html_root_url = "https://docs.rs/palaver/0.2.0")]
 #![warn(
 	missing_copy_implementations,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,6 @@
 //!
 //! `palaver` = "Platform Abstraction Layer" + pa·lav·er *n.* prolonged and tedious fuss.
 
-#![feature(try_from)]
 #![doc(html_root_url = "https://docs.rs/palaver/0.2.0")]
 #![warn(
 	missing_copy_implementations,

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -5,7 +5,7 @@ use super::*;
 #[cfg(unix)]
 use nix::{libc, poll, sys::socket};
 #[cfg(unix)]
-use std::convert::TryInto;
+use try_from::TryInto;
 
 #[cfg(unix)]
 bitflags::bitflags! {

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -9,7 +9,7 @@ use nix::libc;
 	target_os = "ios",
 	target_os = "freebsd"
 ))]
-use std::convert::TryInto;
+use try_from::TryInto;
 
 /// Get an identifier for the thread;
 ///

--- a/src/valgrind.rs
+++ b/src/valgrind.rs
@@ -5,9 +5,9 @@ use super::*;
 #[cfg(unix)]
 use nix::{errno, libc};
 #[cfg(unix)]
-use std::convert::TryInto;
-#[cfg(unix)]
 use std::mem;
+#[cfg(unix)]
+use try_from::TryInto;
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
 fn getrlimit(resource: libc::c_int) -> Result<libc::rlimit64, nix::Error> {

--- a/src/valgrind.rs
+++ b/src/valgrind.rs
@@ -23,6 +23,7 @@ fn getrlimit(resource: libc::c_int) -> Result<libc::rlimit, nix::Error> {
 }
 
 /// Check if we're running under valgrind
+#[cfg(feature = "nightly")]
 pub fn is() -> bool {
 	valgrind_request::running_on_valgrind() > 0
 }

--- a/tests/env.rs
+++ b/tests/env.rs
@@ -23,6 +23,7 @@ fn echo() {
 		.example("echo")
 		.current_release()
 		.current_target()
+		.no_default_features() // https://github.com/crate-ci/escargot/issues/23
 		.run()
 		.unwrap();
 	let echo = echo.path();
@@ -30,6 +31,7 @@ fn echo() {
 		.example("echo_no_main")
 		.current_release()
 		.current_target()
+		.no_default_features() // https://github.com/crate-ci/escargot/issues/23
 		.run()
 		.unwrap();
 	let echo_no_main = echo_no_main.path();


### PR DESCRIPTION
Fixes https://github.com/alecmocatta/palaver/issues/9

I've gated `valgrind_request` behind a "nightly" feature flag. So it can now be excluded with:
```toml
palaver = { version = "0.2", default-features = false }
```

I also switched [`#![feature(try_from)]`](https://github.com/rust-lang/rust/issues/33417) to use the [`try_from`](https://crates.io/crates/try_from) crate. I'll revert this when `#![feature(try_from)]` is stabilised.