### PR TITLE
Give fork more coherent, FreeBSD-inspired semantics

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+[*]
+tab_width = 4
+
+[.*]
+tab_width = 4

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,7 +3,7 @@ pull_request_rules:
     conditions:
       - base=master
       - status-success=tests
-      - label!=work-in-progress
+      - "label!=work in progress"
       - "#approved-reviews-by>=1"
       - "#review-requested=0"
       - "#changes-requested-reviews-by=0"
@@ -17,7 +17,7 @@ pull_request_rules:
     conditions:
       - base=master
       - status-success=tests
-      - label!=work-in-progress
+      - "label!=work in progress"
       - author=alecmocatta # https://github.com/Mergifyio/mergify-engine/issues/451
       - "#review-requested=0"
       - "#changes-requested-reviews-by=0"
@@ -36,10 +36,10 @@ pull_request_rules:
       - "title~=^WIP: .*"
     actions:
       label:
-        add: ["work-in-progress"]
+        add: ["work in progress"]
   - name: auto remove wip label
     conditions:
       - "-title~=^WIP: .*"
     actions:
       label:
-        remove: ["work-in-progress"]
+        remove: ["work in progress"]

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -7,7 +7,6 @@ pull_request_rules:
       - "#approved-reviews-by>=1"
       - "#review-requested=0"
       - "#changes-requested-reviews-by=0"
-      - "#commented-reviews-by=0"
     actions:
       merge:
         method: merge
@@ -21,7 +20,6 @@ pull_request_rules:
       - author=alecmocatta # https://github.com/Mergifyio/mergify-engine/issues/451
       - "#review-requested=0"
       - "#changes-requested-reviews-by=0"
-      - "#commented-reviews-by=0"
     actions:
       merge:
         method: merge

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "palaver"
-version = "0.2.8"
+version = "0.3.0-alpha.1"
 license = "MIT OR Apache-2.0"
 authors = ["Alec Mocatta <alec@mocatta.net>"]
 categories = ["os::unix-apis","os::windows-apis","os::macos-apis"]
@@ -12,7 +12,7 @@ This library attempts to provide reliable polyfills for functionality that isn't
 """
 repository = "https://github.com/alecmocatta/palaver"
 homepage = "https://github.com/alecmocatta/palaver"
-documentation = "https://docs.rs/palaver/0.2.8"
+documentation = "https://docs.rs/palaver/0.3.0-alpha.1"
 readme = "README.md"
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ winapi = { version = "0.3", features = ["processthreadsapi"] }
 mach = "0.3"
 
 [target.'cfg(any(target_os = "android", target_os = "linux"))'.dependencies]
-procinfo = "0.4"
+procfs = { version = "0.7", default-features = false }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,3 +55,6 @@ rand = "0.7"
 [[test]]
 name = "fd_iter"
 harness = false
+[[test]]
+name = "fork"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,10 +23,14 @@ maintenance = { status = "actively-developed" }
 [features]
 nightly = ["valgrind_request"]
 
+[package.metadata.docs.rs]
+all-features = true
+
 [dependencies]
 bitflags = "1.0"
 heapless = "0.5"
 lazy_static = "1.0"
+replace_with = "0.1"
 typenum = "1.10"
 valgrind_request = { version = "1.1", optional = true }
 
@@ -46,11 +50,8 @@ procinfo = "0.4"
 [dev-dependencies]
 serde_json = "1.0"
 escargot = "0.5"
-
-[package.metadata.docs.rs]
-all-features = true
+rand = "0.7"
 
 [[test]]
 name = "fd_iter"
-path = "tests/fd_iter.rs"
 harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ valgrind_request = { version = "1.1", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.47"
-nix = "0.15"
+nix = "0.16"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["processthreadsapi"] }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![MIT / Apache 2.0 licensed](https://img.shields.io/crates/l/palaver.svg?maxAge=2592000)](#License)
 [![Build Status](https://dev.azure.com/alecmocatta/palaver/_apis/build/status/tests?branchName=master)](https://dev.azure.com/alecmocatta/palaver/_build/latest?branchName=master)
 
-[Docs](https://docs.rs/palaver/0.2.8)
+[Docs](https://docs.rs/palaver/0.3.0-alpha.1)
 
 Cross-platform polyfills.
 
@@ -16,41 +16,41 @@ This library attempts to provide reliable polyfills for functionality that isn't
 
 <table><!-- https://github.com/alecmocatta/palaver/new/master to preview changes -->
 <tr><th>Threading</th><th>Description</th><th>Linux</th><th>macOS</th><th>Windows</th><th>FreeBSD</th><th>NetBSD</th><th>iOS</th><th>Android</th></tr>
-<tr><td><a href="https://docs.rs/palaver/0.2.8/palaver/thread/fn.gettid.html"><code>gettid()</code><a></td><td>Get thread ID</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
-<tr><td><a href="https://docs.rs/palaver/0.2.8/palaver/thread/fn.count.html"><code>count()</code></a></td><td>Number of threads in current process</td><td>✓</td><td>✓</td><td> </td><td> </td><td> </td><td>✓</td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.1/palaver/thread/fn.gettid.html"><code>gettid()</code><a></td><td>Get thread ID</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.1/palaver/thread/fn.count.html"><code>count()</code></a></td><td>Number of threads in current process</td><td>✓</td><td>✓</td><td> </td><td> </td><td> </td><td>✓</td><td>✓</td></tr>
 <tr><th>Files</th><th>Description</th><th>Linux</th><th>macOS</th><th>Windows</th><th>FreeBSD</th><th>NetBSD</th><th>iOS</th><th>Android</th></tr>
-<tr><td><a href="https://docs.rs/palaver/0.2.8/palaver/file/fn.seal_fd.html"><code>seal_fd()</code></a></td><td>Make a file descriptor read-only</td><td>✓</td><td>✓</td><td> </td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
-<tr><td><a href="https://docs.rs/palaver/0.2.8/palaver/file/fn.dup_fd.html"><code>dup_fd()</code></a></td><td>Duplicate a file descriptor</td><td>✓</td><td>✓</td><td> </td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
-<tr><td><a href="https://docs.rs/palaver/0.2.8/palaver/file/fn.copy_fd.html"><code>copy_fd()</code></a></td><td>Copy a file descriptor to a specific offset</td><td>✓</td><td>✓</td><td>–</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
-<tr><td><a href="https://docs.rs/palaver/0.2.8/palaver/file/fn.move_fd.html"><code>move_fd()</code></a></td><td>Move a file descriptor to a specific offset</td><td>✓</td><td>✓</td><td>–</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
-<tr><td><a href="https://docs.rs/palaver/0.2.8/palaver/file/fn.move_fds.html"><code>move_fds()</code></a></td><td>Move file descriptors to specific offsets</td><td>✓</td><td>✓</td><td>–</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
-<tr><td><a href="https://docs.rs/palaver/0.2.8/palaver/file/fn.fd_dir.html"><code>fd_dir()</code></a></td><td>Get a path to the file descriptor directory</td><td>✓</td><td>✓</td><td>–</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
-<tr><td><a href="https://docs.rs/palaver/0.2.8/palaver/file/fn.fd_path.html"><code>fd_path()</code></a></td><td>Get a path to a file descriptor</td><td>✓</td><td>✓</td><td>–</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
-<tr><td><a href="https://docs.rs/palaver/0.2.8/palaver/file/struct.FdIter.html"><code>FdIter</code></a></td><td>Iterate all open file descriptors</td><td>✓</td><td>✓</td><td> </td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
-<tr><td><a href="https://docs.rs/palaver/0.2.8/palaver/file/fn.memfd_create.html"><code>memfd_create()</code></a></td><td>Create an anonymous file</td><td>✓</td><td>✓</td><td> </td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
-<tr><td><a href="https://docs.rs/palaver/0.2.8/palaver/file/fn.fexecve.html"><code>fexecve()</code></a></td><td>Execute program specified via file descriptor</td><td>✓</td><td>✓</td><td> </td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
-<tr><td><a href="https://docs.rs/palaver/0.2.8/palaver/file/fn.copy.html"><code>copy()</code></a></td><td>Copy by looping <code>io::copy</code></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
-<tr><td><a href="https://docs.rs/palaver/0.2.8/palaver/file/fn.copy_sendfile.html"><code>copy_sendfile()</code></a></td><td>Copy using <code>sendfile</code></td><td>✓</td><td>✓</td><td> </td><td>✓</td><td> </td><td>✓</td><td>✓</td></tr>
-<tr><td><a href="https://docs.rs/palaver/0.2.8/palaver/file/fn.copy_splice.html"><code>copy_splice()</code></a></td><td>Copy using <code>splice</code></td><td>✓</td><td> </td><td> </td><td> </td><td> </td><td> </td><td>✓</td></tr>
-<tr><td><a href="https://docs.rs/palaver/0.2.8/palaver/file/fn.pipe.html"><code>pipe()</code></a></td><td>Create a pipe</td><td>✓</td><td>✓</td><td> </td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.1/palaver/file/fn.seal_fd.html"><code>seal_fd()</code></a></td><td>Make a file descriptor read-only</td><td>✓</td><td>✓</td><td> </td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.1/palaver/file/fn.dup_fd.html"><code>dup_fd()</code></a></td><td>Duplicate a file descriptor</td><td>✓</td><td>✓</td><td> </td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.1/palaver/file/fn.copy_fd.html"><code>copy_fd()</code></a></td><td>Copy a file descriptor to a specific offset</td><td>✓</td><td>✓</td><td>–</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.1/palaver/file/fn.move_fd.html"><code>move_fd()</code></a></td><td>Move a file descriptor to a specific offset</td><td>✓</td><td>✓</td><td>–</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.1/palaver/file/fn.move_fds.html"><code>move_fds()</code></a></td><td>Move file descriptors to specific offsets</td><td>✓</td><td>✓</td><td>–</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.1/palaver/file/fn.fd_dir.html"><code>fd_dir()</code></a></td><td>Get a path to the file descriptor directory</td><td>✓</td><td>✓</td><td>–</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.1/palaver/file/fn.fd_path.html"><code>fd_path()</code></a></td><td>Get a path to a file descriptor</td><td>✓</td><td>✓</td><td>–</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.1/palaver/file/struct.FdIter.html"><code>FdIter</code></a></td><td>Iterate all open file descriptors</td><td>✓</td><td>✓</td><td> </td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.1/palaver/file/fn.memfd_create.html"><code>memfd_create()</code></a></td><td>Create an anonymous file</td><td>✓</td><td>✓</td><td> </td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.1/palaver/file/fn.fexecve.html"><code>fexecve()</code></a></td><td>Execute program specified via file descriptor</td><td>✓</td><td>✓</td><td> </td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.1/palaver/file/fn.copy.html"><code>copy()</code></a></td><td>Copy by looping <code>io::copy</code></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.1/palaver/file/fn.copy_sendfile.html"><code>copy_sendfile()</code></a></td><td>Copy using <code>sendfile</code></td><td>✓</td><td>✓</td><td> </td><td>✓</td><td> </td><td>✓</td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.1/palaver/file/fn.copy_splice.html"><code>copy_splice()</code></a></td><td>Copy using <code>splice</code></td><td>✓</td><td> </td><td> </td><td> </td><td> </td><td> </td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.1/palaver/file/fn.pipe.html"><code>pipe()</code></a></td><td>Create a pipe</td><td>✓</td><td>✓</td><td> </td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
 <tr><th>Socket</th><th>Description</th><th>Linux</th><th>macOS</th><th>Windows</th><th>FreeBSD</th><th>NetBSD</th><th>iOS</th><th>Android</th></tr>
-<tr><td><a href="https://docs.rs/palaver/0.2.8/palaver/socket/fn.socket.html"><code>socket()</code></a></td><td>Create a socket</td><td>✓</td><td>✓</td><td> </td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
-<tr><td><a href="https://docs.rs/palaver/0.2.8/palaver/socket/fn.accept.html"><code>accept()</code></a></td><td>Accept a connection on a socket</td><td>✓</td><td>✓</td><td> </td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
-<tr><td><a href="https://docs.rs/palaver/0.2.8/palaver/socket/fn.is_connected.html"><code>is_connected()</code></a></td><td>Get whether a pending connection is connected</td><td>✓</td><td>✓</td><td> </td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
-<tr><td><a href="https://docs.rs/palaver/0.2.8/palaver/socket/fn.unreceived.html"><code>unreceived()</code></a></td><td>Get number of bytes readable</td><td>✓</td><td>✓</td><td> </td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
-<tr><td><a href="https://docs.rs/palaver/0.2.8/palaver/socket/fn.unsent.html"><code>unsent()</code></a></td><td>Get number of bytes that have yet to be acknowledged</td><td>✓</td><td>✓</td><td> </td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.1/palaver/socket/fn.socket.html"><code>socket()</code></a></td><td>Create a socket</td><td>✓</td><td>✓</td><td> </td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.1/palaver/socket/fn.accept.html"><code>accept()</code></a></td><td>Accept a connection on a socket</td><td>✓</td><td>✓</td><td> </td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.1/palaver/socket/fn.is_connected.html"><code>is_connected()</code></a></td><td>Get whether a pending connection is connected</td><td>✓</td><td>✓</td><td> </td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.1/palaver/socket/fn.unreceived.html"><code>unreceived()</code></a></td><td>Get number of bytes readable</td><td>✓</td><td>✓</td><td> </td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.1/palaver/socket/fn.unsent.html"><code>unsent()</code></a></td><td>Get number of bytes that have yet to be acknowledged</td><td>✓</td><td>✓</td><td> </td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
 <tr><th>Env</th><th>Description</th><th>Linux</th><th>macOS</th><th>Windows</th><th>FreeBSD</th><th>NetBSD</th><th>iOS</th><th>Android</th></tr>
-<tr><td><a href="https://docs.rs/palaver/0.2.8/palaver/env/fn.exe.html"><code>exe()</code></a></td><td>Opens the current running executable</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
-<tr><td><a href="https://docs.rs/palaver/0.2.8/palaver/env/fn.exe_path.html"><code>exe_path()</code></a></td><td>Get a path to the current running executable</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
-<tr><td><a href="https://docs.rs/palaver/0.2.8/palaver/env/fn.args.html"><code>args()</code></a></td><td>Get command line arguments</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
-<tr><td><a href="https://docs.rs/palaver/0.2.8/palaver/env/fn.vars.html"><code>vars()</code></a></td><td>Get environment variables</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.1/palaver/env/fn.exe.html"><code>exe()</code></a></td><td>Opens the current running executable</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.1/palaver/env/fn.exe_path.html"><code>exe_path()</code></a></td><td>Get a path to the current running executable</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.1/palaver/env/fn.args.html"><code>args()</code></a></td><td>Get command line arguments</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.1/palaver/env/fn.vars.html"><code>vars()</code></a></td><td>Get environment variables</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
 <tr><th>Process</th><th>Description</th><th>Linux</th><th>macOS</th><th>Windows</th><th>FreeBSD</th><th>NetBSD</th><th>iOS</th><th>Android</th></tr>
-<tr><td><a href="https://docs.rs/palaver/0.2.8/palaver/process/fn.count.html"><code>count()</code></a></td><td>Count the processes visible to the current process</td><td>✓</td><td>✓</td><td>–</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
-<tr><td><a href="https://docs.rs/palaver/0.2.8/palaver/process/fn.count_threads.html"><code>count_threads()</code></a></td><td>Count the threads visible to the current process</td><td>✓</td><td>✓</td><td>–</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
-<tr><td><a href="https://docs.rs/palaver/0.2.8/palaver/process/fn.fork.html"><code>fork()</code></a></td><td>Fork a process, using process descriptors where available</td><td>✓</td><td>✓</td><td>–</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.1/palaver/process/fn.count.html"><code>count()</code></a></td><td>Count the processes visible to the current process</td><td>✓</td><td>✓</td><td>–</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.1/palaver/process/fn.count_threads.html"><code>count_threads()</code></a></td><td>Count the threads visible to the current process</td><td>✓</td><td>✓</td><td>–</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.1/palaver/process/fn.fork.html"><code>fork()</code></a></td><td>Fork a process, using process descriptors where available</td><td>✓</td><td>✓</td><td>–</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
 <tr><th>Valgrind</th><th>Description</th><th>Linux</th><th>macOS</th><th>Windows</th><th>FreeBSD</th><th>NetBSD</th><th>iOS</th><th>Android</th></tr>
-<tr><td><a href="https://docs.rs/palaver/0.2.8/palaver/valgrind/fn.is.html"><code>is()</code></a></td><td>Check if running under Valgrind</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
-<tr><td><a href="https://docs.rs/palaver/0.2.8/palaver/valgrind/fn.start_fd.html"><code>start_fd()</code></a></td><td>Get Valgrind's file descriptor range</td><td>✓</td><td>✓</td><td>–</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.1/palaver/valgrind/fn.is.html"><code>is()</code></a></td><td>Check if running under Valgrind</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.1/palaver/valgrind/fn.start_fd.html"><code>start_fd()</code></a></td><td>Get Valgrind's file descriptor range</td><td>✓</td><td>✓</td><td>–</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
 </table>
 
 ## License

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ jobs:
     endpoint: alecmocatta
     default:
       rust_toolchain: stable nightly
-      rust_lint_toolchain: nightly-2019-08-15
+      rust_lint_toolchain: nightly-2020-01-25
       rust_flags: ''
       rust_features: ''
       rust_target_check: ''

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,8 +26,8 @@ jobs:
         rust_target_run: 'x86_64-pc-windows-msvc i686-pc-windows-msvc' # currently broken building crate-type=lib: x86_64-pc-windows-gnu i686-pc-windows-gnu
       mac:
         imageName: 'macos-10.13'
-        rust_target_build: 'aarch64-apple-ios armv7-apple-ios armv7s-apple-ios i386-apple-ios x86_64-apple-ios'
-        rust_target_run: 'x86_64-apple-darwin i686-apple-darwin'
+        rust_target_build: 'aarch64-apple-ios x86_64-apple-ios'
+        rust_target_run: 'x86_64-apple-darwin'
       linux:
         imageName: 'ubuntu-16.04'
         rust_target_check: 'x86_64-unknown-freebsd x86_64-unknown-netbsd' # x86_64-sun-solaris aarch64-linux-android armv7-linux-androideabi i686-linux-android

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,6 +11,7 @@ resources:
 jobs:
 - template: rust.yml@templates
   parameters:
+    endpoint: alecmocatta
     default:
       rust_toolchain: stable nightly
       rust_lint_toolchain: nightly-2019-07-19

--- a/src/env.rs
+++ b/src/env.rs
@@ -15,19 +15,17 @@
 //! use std::io::Read;
 //! use palaver::env::exe;
 //!
-//! # fn main() {
 //! let mut current_binary = vec![];
 //! exe().unwrap().read_to_end(&mut current_binary).unwrap();
 //! println!("Current binary is {} bytes long!", current_binary.len());
-//! # }
 //! ```
 //!
 //! ```
 //! use palaver::env;
 //!
 //! pub fn my_library_func() {
-//! 	let args = env::args();
-//! 	let vars = env::vars();
+//!     let args = env::args();
+//!     let vars = env::vars();
 //! }
 //! ```
 

--- a/src/env.rs
+++ b/src/env.rs
@@ -384,7 +384,7 @@ mod tests {
 			argv_from_proc().ok(),
 			Some(std::env::args_os().collect::<Vec<_>>()),
 		];
-		let mut args2 = args.clone().into_iter().flat_map(|x| x).collect::<Vec<_>>();
+		let mut args2 = args.clone().into_iter().flatten().collect::<Vec<_>>();
 		args2.dedup();
 		assert!(args2.len() == 1, "{:?}", args);
 
@@ -394,7 +394,7 @@ mod tests {
 			envp_from_proc().ok(),
 			Some(std::env::vars_os().collect::<Vec<_>>()),
 		];
-		let mut args2 = args.clone().into_iter().flat_map(|x| x).collect::<Vec<_>>();
+		let mut args2 = args.clone().into_iter().flatten().collect::<Vec<_>>();
 		args2.dedup();
 		assert!(args2.len() == 1, "{:?}", args);
 	}

--- a/src/env.rs
+++ b/src/env.rs
@@ -345,6 +345,7 @@ pub static GRAB_ARGV_ENVP: extern "C" fn(
 	envp: *const *const c_char,
 ) = {
 	// Or should it be an array? https://github.com/rust-lang/rust/pull/39987#issue-107077124 https://doc.rust-lang.org/unstable-book/language-features/used.html
+	#[cfg_attr(target_os = "linux", link_section = ".text.startup")]
 	extern "C" fn grab_argv_envp(
 		_argc: libc::c_int, argv: *const *const c_char, envp: *const *const c_char,
 	) {

--- a/src/file.rs
+++ b/src/file.rs
@@ -22,6 +22,7 @@ use std::{
 };
 
 #[doc(inline)]
+#[cfg(unix)]
 pub use fcntl::{FdFlag, OFlag};
 
 /// Maps file descriptors [(from,to)]
@@ -292,7 +293,7 @@ fn tmpfile(
 	// let rand = fs::File::open("/dev/urandom").expect("Couldn't open /dev/urandom");
 	let rand = nix::fcntl::open(
 		"/dev/urandom",
-		nix::OFlag::O_RDONLY,
+		OFlag::O_RDONLY,
 		nix::sys::stat::Mode::empty(),
 	)
 	.expect("Couldn't open /dev/urandom");

--- a/src/file.rs
+++ b/src/file.rs
@@ -660,9 +660,9 @@ pub fn fd_path_heapless(fd: Fd) -> io::Result<heapless::String<heapless::consts:
 /// // Close all file descriptors except std{in,out,err}.
 /// # #[cfg(unix)]
 /// for fd in FdIter::new().unwrap() {
-/// 	if fd > 2 {
-/// 		nix::unistd::close(fd).unwrap();
-/// 	}
+///     if fd > 2 {
+///         nix::unistd::close(fd).unwrap();
+///     }
 /// }
 /// ```
 pub struct FdIter(#[cfg(unix)] *mut libc::DIR);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,11 @@
 	clippy::if_not_else,
 	clippy::shadow_unrelated,
 	clippy::similar_names,
-	clippy::module_name_repetitions
+	clippy::module_name_repetitions,
+	clippy::empty_loop,
+	clippy::must_use_candidate,
+	clippy::missing_errors_doc,
+	clippy::same_functions_in_if_condition
 )]
 
 pub mod env;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 //!
 //! `palaver` = "Platform Abstraction Layer" + pa·lav·er *n.* prolonged and tedious fuss.
 
-#![doc(html_root_url = "https://docs.rs/palaver/0.2.8")]
+#![doc(html_root_url = "https://docs.rs/palaver/0.3.0-alpha.1")]
 #![warn(
 	missing_copy_implementations,
 	missing_debug_implementations,
@@ -25,9 +25,9 @@
 	clippy::missing_errors_doc,
 	clippy::module_name_repetitions,
 	clippy::must_use_candidate,
-	clippy::same_functions_in_if_condition
+	clippy::same_functions_in_if_condition,
 	clippy::shadow_unrelated,
-	clippy::similar_names,
+	clippy::similar_names
 )]
 
 pub mod env;
@@ -39,6 +39,8 @@ pub mod thread;
 #[cfg(unix)]
 pub mod valgrind;
 
+#[doc(hidden)]
+#[deprecated]
 pub use process as fork;
 
 #[cfg(unix)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,14 +20,14 @@
 )] // from https://github.com/rust-unofficial/patterns/blob/master/anti_patterns/deny-warnings.md
 #![allow(
 	clippy::doc_markdown,
+	clippy::empty_loop,
 	clippy::if_not_else,
+	clippy::missing_errors_doc,
+	clippy::module_name_repetitions,
+	clippy::must_use_candidate,
+	clippy::same_functions_in_if_condition
 	clippy::shadow_unrelated,
 	clippy::similar_names,
-	clippy::module_name_repetitions,
-	clippy::empty_loop,
-	clippy::must_use_candidate,
-	clippy::missing_errors_doc,
-	clippy::same_functions_in_if_condition
 )]
 
 pub mod env;

--- a/src/process.rs
+++ b/src/process.rs
@@ -205,7 +205,6 @@ pub enum ForkResult {
 /// ```
 // See also https://github.com/qt/qtbase/blob/v5.12.0/src/3rdparty/forkfd/forkfd.c
 #[cfg(unix)]
-#[allow(clippy::too_many_lines)]
 pub fn fork(orphan: bool) -> nix::Result<ForkResult> {
 	if orphan {
 		// inspired by fork2 http://www.faqs.org/faqs/unix-faq/programmer/faq/

--- a/src/process.rs
+++ b/src/process.rs
@@ -69,6 +69,7 @@ struct Handle {
 }
 
 /// Possible return values from [`ChildHandle::wait`].
+#[cfg(unix)]
 #[derive(Clone, Copy, Debug)]
 pub enum WaitStatus {
 	/// The process exited normally (as with `exit()` or returning from
@@ -350,6 +351,7 @@ pub fn fork(orphan: bool) -> nix::Result<ForkResult> {
 	}
 }
 
+#[cfg(unix)]
 fn basic_fork(may_outlive: bool) -> nix::Result<ForkResult> {
 	#[cfg(target_os = "freebsd")]
 	{

--- a/src/process.rs
+++ b/src/process.rs
@@ -14,6 +14,7 @@ use std::{
 use crate::{file, Fd};
 
 #[doc(inline)]
+#[cfg(unix)]
 pub use signal::Signal;
 
 /// Count the number of processes visible to this process. Counts the lines of `ps aux` minus one (the header).

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,8 +1,6 @@
 //! Process-related functionality
 
 #[cfg(unix)]
-use crate::{file, Fd};
-#[cfg(unix)]
 use nix::{
 	cmsg_space, errno::Errno, fcntl, libc, sys::socket, sys::uio, sys::{signal, wait}, unistd::{self, Pid}, Error
 };
@@ -11,6 +9,9 @@ use std::process::Command;
 use std::{
 	os::unix::io::AsRawFd, os::unix::net::UnixDatagram, sync::atomic::{AtomicU8, Ordering}
 };
+
+#[cfg(unix)]
+use crate::{file, Fd};
 
 /// Count the number of processes visible to this process. Counts the lines of `ps aux` minus one (the header).
 pub fn count() -> usize {

--- a/src/process.rs
+++ b/src/process.rs
@@ -13,6 +13,9 @@ use std::{
 #[cfg(unix)]
 use crate::{file, Fd};
 
+#[doc(inline)]
+pub use signal::Signal;
+
 /// Count the number of processes visible to this process. Counts the lines of `ps aux` minus one (the header).
 pub fn count() -> usize {
 	let out = Command::new("ps")
@@ -80,7 +83,7 @@ pub enum WaitStatus {
 	/// indicates whether the signal generated a core dump. This case
 	/// matches the C macro `WIFSIGNALED(status)`; the last two fields
 	/// correspond to `WTERMSIG(status)` and `WCOREDUMP(status)`.
-	Signaled(signal::Signal, bool),
+	Signaled(Signal, bool),
 }
 
 #[cfg(unix)]
@@ -114,7 +117,7 @@ impl ChildHandle {
 	}
 	/// Signal the child process
 	#[allow(unreachable_code)]
-	pub fn signal<T: Into<Option<signal::Signal>>>(&self, signal: T) -> nix::Result<()> {
+	pub fn signal<T: Into<Option<Signal>>>(&self, signal: T) -> nix::Result<()> {
 		let signal = signal.into();
 		#[cfg(target_os = "freebsd")]
 		{
@@ -175,7 +178,7 @@ pub enum ForkResult {
 	Child,
 }
 
-/// A Rust fork wrapper that provides more coherent, FreeBSD-inspired semantics:
+/// A Rust fork wrapper that provides more coherent, FreeBSD-inspired semantics.
 ///
 /// - immune to PID race conditions (see [here](https://lwn.net/Articles/773459/) for a description of the race);
 /// - thus it's possible to `waitpid()` on one thread and `kill()` on another without a race;

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,19 +1,18 @@
 //! Process-related functionality
 
 #[cfg(unix)]
-use crate::{file, Fd};
+use crate::{
+	file::{self, fd_path}, Fd
+};
 #[cfg(unix)]
 use nix::{
-	fcntl, libc, poll, sys::{signal, wait}, unistd::{self, Pid}
+	cmsg_space, errno::Errno, fcntl, libc, sys::socket, sys::uio, sys::{signal, wait}, unistd::{self, Pid}, Error
 };
 use std::process::Command;
 #[cfg(unix)]
 use std::{
-	convert::{TryFrom, TryInto}, ptr, sync::atomic::{AtomicU8, Ordering}
+	convert::{TryFrom, TryInto}, os::unix::io::AsRawFd, os::unix::net::UnixDatagram, ptr, sync::atomic::{AtomicU8, Ordering}
 };
-
-#[cfg(target_os = "freebsd")]
-use super::Fd;
 
 /// Count the number of processes visible to this process. Counts the lines of `ps aux` minus one (the header).
 pub fn count() -> usize {
@@ -52,21 +51,22 @@ pub fn count_threads() -> usize {
 
 /// Child process handle
 #[cfg(unix)]
-// #[allow(missing_copy_implementations)]
 #[derive(Debug)]
 pub struct ChildHandle {
 	/// Child Process ID
 	pub pid: Pid,
-	#[cfg(target_os = "freebsd")]
 	/// Child Process Descriptor
+	#[cfg(target_os = "freebsd")]
 	pub pd: Fd,
 	owns: Option<Handle>,
 }
+
 #[cfg(unix)]
 #[derive(Debug)]
 struct Handle {
 	state: AtomicU8, // 0, 1 = killed, 2 = reaped
-	pipe_write: Fd,
+	#[cfg(not(target_os = "freebsd"))]
+	eternal_write: Fd,
 }
 
 /// Possible return values from [`ChildHandle::wait`].
@@ -86,9 +86,8 @@ pub enum WaitStatus {
 #[cfg(unix)]
 impl ChildHandle {
 	/// Signal the child process
+	// TODO: catch multiple waiters
 	pub fn wait(&self) -> nix::Result<WaitStatus> {
-		// EVFILT_PROCDESC on freebsd?
-		// linux? https://lwn.net/Articles/773459/
 		let ret = Self::wait_(self.pid);
 		if let (Ok(_), Some(owns)) = (ret, &self.owns) {
 			owns.state.store(2, Ordering::Relaxed);
@@ -97,7 +96,7 @@ impl ChildHandle {
 	}
 	fn wait_(pid: Pid) -> nix::Result<WaitStatus> {
 		// EVFILT_PROCDESC on freebsd?
-		// linux? https://lwn.net/Articles/784831/
+		// pidfd linux? https://lwn.net/Articles/784831/ https://lwn.net/Articles/794707/ https://github.com/pop-os/pidfd
 		loop {
 			match wait::waitpid(pid, None) {
 				Ok(wait::WaitStatus::Exited(pid_, code)) => {
@@ -108,38 +107,36 @@ impl ChildHandle {
 					assert_eq!(pid_, pid);
 					break Ok(WaitStatus::Signaled(signal, dumped));
 				}
-				Ok(_) | Err(nix::Error::Sys(nix::errno::Errno::EINTR)) => (),
+				Ok(_) | Err(Error::Sys(Errno::EINTR)) => (),
 				Err(err) => break Err(err),
 			}
 		}
 	}
 	/// Signal the child process
+	#[allow(unreachable_code)]
 	pub fn signal<T: Into<Option<signal::Signal>>>(&self, signal: T) -> nix::Result<()> {
+		let signal = signal.into();
+		#[cfg(target_os = "freebsd")]
+		{
+			let res = unsafe {
+				libc::pdkill(
+					self.pd,
+					match signal {
+						Some(s) => s as libc::c_int,
+						None => 0,
+					},
+				)
+			};
+			return Errno::result(res).map(drop);
+		}
 		let owns = self
 			.owns
 			.as_ref()
 			.expect(".signal() can only be called on non-orphaned children");
-		let signal = signal.into();
 		if owns.state.load(Ordering::Relaxed) != 0 {
-			return Err(nix::Error::Sys(nix::errno::Errno::ESRCH)); //optimisation, not necessary for correctness
+			return Err(Error::Sys(Errno::ESRCH));
 		}
-		{
-			#[cfg(target_os = "freebsd")]
-			{
-				let res = unsafe {
-					libc::pdkill(
-						self.pd,
-						match signal {
-							Some(s) => s as libc::c_int,
-							None => 0,
-						},
-					)
-				};
-				Errno::result(res).map(drop)
-			}
-			#[cfg(not(target_os = "freebsd"))]
-			signal::kill(self.pid, signal)
-		}?;
+		signal::kill(self.pid, signal)?;
 		if signal == Some(signal::SIGKILL) {
 			let _ = owns.state.compare_and_swap(0, 1, Ordering::Relaxed);
 		}
@@ -158,30 +155,18 @@ impl Drop for ChildHandle {
 			if state != 2 {
 				let _ = self.wait().expect("b");
 			}
-			unistd::close(self.owns.as_mut().unwrap().pipe_write).unwrap();
 			let group = Pid::from_raw(-self.pid.as_raw());
-			// panic!();
-			// eprintln!("{}", format!("kill2 {}", group));
 			signal::kill(group, signal::SIGKILL).expect("c");
-			// let status = ChildHandle::wait_(Pid::from_raw(-self.pid.as_raw())).expect("d");
-			// assert!(matches!(status, WaitStatus::Signaled(signal::SIGKILL, _)), "{:?}", status);
+			#[cfg(not(target_os = "freebsd"))]
+			unistd::close(self.owns.as_mut().unwrap().eternal_write).unwrap();
 		}
-		// {
-		// 	signal::kill(self.pid, signal::SIGKILL).unwrap();
-		// 	let a = a.wait().unwrap();
-		// 	assert!(matches!(a, WaitStatus::Signaled(signal::SIGKILL, _)), "{:?}", a);
-		// }
 		#[cfg(target_os = "freebsd")]
-		{
-			let err = unsafe { libc::close(self.pd) };
-			assert_eq!(err, 0);
-		}
+		unistd::close(self.pd).unwrap();
 	}
 }
 
 /// Fork result
 #[cfg(unix)]
-#[allow(missing_copy_implementations)]
 #[derive(Debug)]
 pub enum ForkResult {
 	/// Parent process
@@ -190,24 +175,30 @@ pub enum ForkResult {
 	Child,
 }
 
-/// A Rust fork wrapper that uses process descriptors (pdfork) on FreeBSD and normal fork elsewhere.
+/// A Rust fork wrapper that provides more coherent, FreeBSD-inspired semantics:
 ///
-/// Process descriptors are like file descriptors but for processes:
-/// - they are immune to PID race conditions (they track the exact process in the kernel);
-/// - they work in the [Capsicum](https://wiki.freebsd.org/Capsicum) capability mode sandbox.
+/// - immune to PID race conditions (see [here](https://lwn.net/Articles/773459/) for a description of the race);
+/// - thus it's possible to `waitpid()` on one thread and `kill()` on another without a race;
+/// - option to orphan a process, i.e. hand it off to init;
+/// - child processes are killed on parent termination;
+/// - and it works in the [Capsicum](https://wiki.freebsd.org/Capsicum) capability mode sandbox.
 ///
+/// It's implemented using process descriptors (pdfork) on FreeBSD and normal fork elsewhere.
+///
+/// ## Caveats
+/// - Child process killing on parent termination relies on maintaining an fd (except freebsd) and a thread (except freebsd and linux) in the child; if this isn't possible then pass false for `can_use_fd`.
+///
+/// # Example
 /// ```no_run
-/// extern crate libc;
-/// extern crate palaver;
 /// use palaver::process::*;
 ///
-/// match fork().unwrap() {
+/// match fork(false, true).unwrap() {
 ///     ForkResult::Parent(child_proc) => {
 ///         // do stuff
 ///         // you can access child_proc.pid on any platform
 ///         // you can also access child_proc.pd on FreeBSD
-///         if !child_proc.signal(libc::SIGTERM) {
-///             panic!("sigterm");
+///         if let Err(err) = child_proc.signal(nix::sys::signal::SIGTERM) {
+///             panic!("sigterm: {:?}", err);
 ///         }
 ///     },
 ///     ForkResult::Child => {
@@ -215,190 +206,264 @@ pub enum ForkResult {
 ///     }
 /// }
 /// ```
-
-struct StdErr;
-impl std::io::Write for StdErr {
-	fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-		use std::os::unix::io::{FromRawFd, IntoRawFd};
-		let mut file = unsafe { std::fs::File::from_raw_fd(libc::STDERR_FILENO) };
-		let ret = file.write(buf);
-		let _ = file.into_raw_fd();
+// See also https://github.com/qt/qtbase/blob/v5.12.0/src/3rdparty/forkfd/forkfd.c
+#[cfg(unix)]
+#[allow(clippy::too_many_lines)]
+pub fn fork(orphan: bool, can_use_fd: bool) -> nix::Result<ForkResult> {
+	if orphan {
+		// inspired by fork2 http://www.faqs.org/faqs/unix-faq/programmer/faq/
+		// TODO: how to make this not racy?
+		let new = signal::SigAction::new(
+			signal::SigHandler::SigDfl,
+			signal::SaFlags::empty(),
+			signal::SigSet::empty(),
+		);
+		let old = unsafe { signal::sigaction(signal::SIGCHLD, &new).unwrap() };
+		let ret = (|| {
+			let child = if let ForkResult::Parent(child) = basic_fork(false)? {
+				child
+			} else {
+				match basic_fork(true) {
+					Ok(ForkResult::Child) => {
+						return Ok(ForkResult::Child);
+					}
+					Ok(ForkResult::Parent(_)) => unsafe { libc::_exit(0) },
+					Err(_) => unsafe { libc::_exit(1) },
+				}
+			};
+			let exit = child.wait().unwrap();
+			if let WaitStatus::Exited(0) = exit {
+				let pid = Pid::from_raw(i32::max_value()); // TODO!
+				#[cfg(target_os = "freebsd")]
+				let pd = i32::max_value(); // TODO!
+				Ok(ForkResult::Parent(ChildHandle {
+					pid,
+					#[cfg(target_os = "freebsd")]
+					pd,
+					owns: None,
+				}))
+			} else {
+				Err(Error::Sys(Errno::UnknownErrno))
+			}
+		})();
+		if new.handler() != old.handler() {
+			let new2 = unsafe { signal::sigaction(signal::SIGCHLD, &old).unwrap() };
+			assert_eq!(new.handler(), new2.handler());
+		}
 		ret
-	}
-	fn flush(&mut self) -> std::io::Result<()> {
-		Ok(())
+	} else {
+		if cfg!(target_os = "freebsd") {
+			return basic_fork(false);
+		}
+		let (ready_write, ready_read) = UnixDatagram::pair().unwrap();
+		Ok(match basic_fork(false)? {
+			ForkResult::Child => {
+				drop(ready_read);
+				let (eternal_read, eternal_write) = file::pipe(fcntl::OFlag::empty()).unwrap();
+				let pid = unistd::getpid();
+				let group = unistd::getpgrp();
+				let our_group_retainer = if group != pid {
+					let child = if let ForkResult::Parent(child) = basic_fork(false)? {
+						child
+					} else {
+						drop(ready_write);
+						let err = unistd::read(eternal_read, &mut [0]).unwrap();
+						assert_eq!(err, 0);
+						signal::kill(unistd::getpid(), signal::SIGKILL).unwrap();
+						loop {}
+					};
+					unistd::setpgid(unistd::Pid::from_raw(0), unistd::Pid::from_raw(0)).unwrap();
+					Some(child)
+				} else {
+					None
+				};
+				let _our_pid_retainer = if let ForkResult::Parent(child) = basic_fork(false)? {
+					child
+				} else {
+					drop(ready_write);
+					for fd in 0..1024 {
+						// TODO // && fd > 2 {
+						if fd != eternal_read {
+							let _ = unistd::close(fd);
+						}
+					}
+					let err = unistd::read(eternal_read, &mut [0]).unwrap();
+					assert_eq!(err, 0);
+					signal::kill(unistd::getpid(), signal::SIGKILL).unwrap();
+					loop {}
+				};
+				if !can_use_fd {
+					unistd::close(eternal_read).unwrap();
+				}
+				let iov = [uio::IoVec::from_slice(&[])];
+				let fds = [eternal_write];
+				let cmsg = [socket::ControlMessage::ScmRights(&fds)];
+				let _ = socket::sendmsg(
+					ready_write.as_raw_fd(),
+					&iov,
+					&cmsg,
+					socket::MsgFlags::empty(),
+					None,
+				)
+				.map(|x| {
+					assert_eq!(x, 0);
+				});
+				drop(ready_write);
+				unistd::close(eternal_write).unwrap();
+				if let Some(retainer) = our_group_retainer {
+					let group = unistd::getpgid(Some(retainer.pid)).unwrap_or(group); // slightly more immune to races than getpgrp?
+					unistd::setpgid(unistd::Pid::from_raw(0), group).unwrap();
+					signal::kill(retainer.pid, signal::SIGKILL).unwrap();
+					let _ = retainer.wait().unwrap();
+				}
+				// assert_eq!(unistd::getpgid(Some(our_pid_retainer.pid)).unwrap(), pid);
+
+				// die if our owning process dies
+				// PR_SET_PDEATHSIG kills if the parent *thread* (not process) exits http://man7.org/linux/man-pages/man2/prctl.2.html
+				// this can be resolved by calling clone twice (first with CLONE_THREAD then without), but it's tricky to ensure grandchild gets the initial stack
+				// probably requires assembly?
+				// PR_SET_KILL_DESCENDANTS_ON_EXIT potential
+				if can_use_fd {
+					if cfg!(any(target_os = "android", target_os = "linux")) {
+						const F_SETSIG: libc::c_int = 10;
+						let eternal_read = fcntl::open(
+							&fd_path(eternal_read).unwrap(),
+							fcntl::OFlag::O_RDONLY,
+							nix::sys::stat::Mode::empty(),
+						)
+						.unwrap();
+						unsafe {
+							let err = libc::fcntl(eternal_read, F_SETSIG, libc::SIGKILL);
+							assert_eq!(err, 0);
+							let err = libc::fcntl(eternal_read, libc::F_SETOWN, unistd::getpid());
+							assert_eq!(err, 0);
+						}
+						let err = fcntl::fcntl(
+							eternal_read,
+							fcntl::FcntlArg::F_SETFL(
+								fcntl::OFlag::O_NONBLOCK | fcntl::OFlag::O_ASYNC,
+							),
+						)
+						.unwrap();
+						assert_eq!(err, 0);
+						if let Ok(0) = unistd::read(eternal_read, &mut [0]) {
+							signal::kill(unistd::getpid(), signal::SIGKILL).unwrap();
+							loop {}
+						}
+					} else {
+						// mac: https://stackoverflow.com/questions/2211951/aio-on-os-x-vs-linux-why-it-doesnt-work-on-mac-os-x-10-6
+						// is pthread_create an issue if fork called in multithreaded context? if so, here's rolling our own:
+						// const STACK_SIZE: usize = 4096; // enough for anybody
+						// let stack: *mut u8 = nix::sys::mman::mmap(
+						// 	ptr::null_mut(),
+						// 	STACK_SIZE,
+						// 	nix::sys::mman::ProtFlags::PROT_READ
+						// 		| nix::sys::mman::ProtFlags::PROT_WRITE,
+						// 	nix::sys::mman::MapFlags::MAP_PRIVATE
+						// 		| nix::sys::mman::MapFlags::MAP_ANON,
+						// 	-1,
+						// 	0,
+						// )
+						// .unwrap() as _;
+						// let child = unsafe {
+						// 	libc::clone(
+						// 		thread,
+						// 		stack.add(STACK_SIZE) as _,
+						// 		libc::CLONE_VM,
+						// 		usize::try_from(eternal_read).unwrap() as _,
+						// 	)
+						// };
+						// assert_ne!(child, -1);
+						#[inline]
+						fn abort_on_unwind<F: FnOnce() -> T, T>(f: F) -> T {
+							replace_with::on_unwind(f, || {
+								std::process::abort();
+							})
+						}
+						extern "C" fn thread(arg: *mut libc::c_void) -> *mut libc::c_void {
+							abort_on_unwind(|| {
+								let eternal_read: i32 = (arg as usize).try_into().unwrap();
+								let err = unistd::read(eternal_read, &mut [0]).unwrap();
+								assert_eq!(err, 0);
+								signal::kill(unistd::getpid(), signal::SIGKILL).unwrap();
+								loop {}
+							})
+						}
+						let mut native: libc::pthread_t = 0;
+						let res = unsafe {
+							libc::pthread_create(
+								&mut native,
+								ptr::null(),
+								thread,
+								usize::try_from(eternal_read).unwrap() as _,
+							)
+						};
+						assert_eq!(res, 0);
+					}
+				}
+				ForkResult::Child
+			}
+			ForkResult::Parent(mut child) => {
+				drop(ready_write);
+				let mut buf = [0; 8];
+				let iovec = [uio::IoVec::from_mut_slice(&mut buf)];
+				let mut space = cmsg_space!([Fd; 2]);
+				let eternal_write = socket::recvmsg(
+					ready_read.as_raw_fd(),
+					&iovec,
+					Some(&mut space),
+					socket::MsgFlags::empty(),
+				)
+				.map(|msg| {
+					let mut iter = msg.cmsgs();
+					match (iter.next(), iter.next()) {
+						(Some(socket::ControlMessageOwned::ScmRights(fds)), None) => {
+							assert_eq!(msg.bytes, 0);
+							assert_eq!(fds.len(), 1);
+							fds[0]
+						}
+						_ => panic!(),
+					}
+				})
+				.unwrap();
+				drop(ready_read);
+				child.owns = Some(Handle {
+					state: AtomicU8::new(0),
+					#[cfg(not(target_os = "freebsd"))]
+					eternal_write,
+				});
+				let _ = eternal_write;
+				ForkResult::Parent(child)
+			}
+		})
 	}
 }
 
-// See also https://github.com/qt/qtbase/blob/v5.12.0/src/3rdparty/forkfd/forkfd.c
-#[cfg(unix)]
-pub fn fork(orphan: bool) -> nix::Result<ForkResult> {
+fn basic_fork(may_outlive: bool) -> nix::Result<ForkResult> {
 	#[cfg(target_os = "freebsd")]
 	{
-		if orphan {
-			unimplemented!();
-		}
-		let mut child_pd = -1;
-		let child_pid = unsafe { libc::pdfork(&mut child_pd, 0) };
-		if child_pid < 0 {
-			Err(())
-		} else if child_pid > 0 {
-			Ok(ForkResult::Parent(ChildHandle {
-				child_pid,
-				child_pd,
-				owns: true,
-			}))
-		} else {
-			Ok(ForkResult::Child)
-		}
+		let mut pd = -1;
+		let res = unsafe { libc::pdfork(&mut pd, if may_outlive { libc::PD_DAEMON } else { 0 }) };
+		Errno::result(res).map(|res| match res {
+			0 => ForkResult::Child,
+			pid => ForkResult::Parent(ChildHandle {
+				pid: Pid::from_raw(pid),
+				pd,
+				owns: None,
+			}),
+		})
 	}
 	#[cfg(not(target_os = "freebsd"))]
 	{
-		if orphan {
-			// inspired by fork2 http://www.faqs.org/faqs/unix-faq/programmer/faq/
-			// TODO: how to make this not racy?
-			let new = signal::SigAction::new(
-				signal::SigHandler::SigDfl,
-				signal::SaFlags::empty(),
-				signal::SigSet::empty(),
-			);
-			let old = unsafe { signal::sigaction(signal::SIGCHLD, &new).unwrap() };
-			let ret = (|| {
-				let child = if let ForkResult::Parent(child) = basic_fork()? {
-					child
-				} else {
-					match basic_fork() {
-						Ok(ForkResult::Child) => {
-							return Ok(ForkResult::Child);
-						}
-						Ok(ForkResult::Parent(_)) => unsafe { libc::_exit(0) },
-						Err(_) => unsafe { libc::_exit(1) },
-					}
-				};
-				let exit = child.wait().unwrap();
-				if let WaitStatus::Exited(0) = exit {
-					let pid = Pid::from_raw(i32::max_value()); // TODO!
-					Ok(ForkResult::Parent(ChildHandle { pid, owns: None }))
-				} else {
-					Err(nix::Error::Sys(nix::errno::Errno::UnknownErrno))
-				}
-			})();
-			let new2 = unsafe { signal::sigaction(signal::SIGCHLD, &old).unwrap() };
-			assert_eq!(new.handler(), new2.handler());
-			ret
-		} else {
-			let (pipe_read, pipe_write) = file::pipe(fcntl::OFlag::empty())?;
-			Ok(match basic_fork()? {
-				ForkResult::Child => {
-					unistd::close(pipe_write).unwrap();
-					let a = if let ForkResult::Parent(child) = basic_fork()? {
-						child
-					} else {
-						loop {
-							unistd::pause();
-						}
-					};
-					let group = unistd::getpgrp();
-					unistd::setpgid(unistd::Pid::from_raw(0), unistd::Pid::from_raw(0)).unwrap();
-					let b = if let ForkResult::Parent(child) = basic_fork()? {
-						child
-					} else {
-						for fd in 0..1024 {
-							let _ = unistd::close(fd);
-						}
-						loop {
-							unistd::pause();
-						}
-					};
-					signal::kill(a.pid, signal::SIGKILL).unwrap();
-					let status = a.wait().unwrap();
-					assert!(
-						matches!(status, WaitStatus::Signaled(signal::SIGKILL, _)),
-						"{:?}",
-						status
-					);
-					unistd::setpgid(unistd::Pid::from_raw(0), group).unwrap();
-					assert_eq!(unistd::getpgid(Some(b.pid)).unwrap(), unistd::getpid());
-					// signal::kill(Pid::from_raw(-unistd::getpid().as_raw()), signal::SIGKILL).unwrap();
-					// let b = b.wait().unwrap();
-					// assert!(matches!(b, WaitStatus::Signaled(signal::SIGKILL, _)), "{:?}", a);
-					// die if our owning process dies
-					// PR_SET_PDEATHSIG would kill us if thread exits http://man7.org/linux/man-pages/man2/prctl.2.html
-					extern "C" fn thread(arg: *mut libc::c_void) -> *mut libc::c_void {
-						// TODO: abort on unwind
-						let pipe_read: i32 = (arg as usize).try_into().unwrap();
-						// std::thread::spawn(move||{
-						let mut pollfds = [poll::PollFd::new(pipe_read, poll::PollFlags::POLLHUP)];
-						let n = poll::poll(&mut pollfds, -1).unwrap();
-						// assert_eq!(n, 1);
-						// let err = unistd::read(pipe_read, &mut [0]);
-						// let err2 = unistd::read(pipe_read, &mut [0]);
-						// use std::io::Write;
-						// StdErr.write_all(format!("aaaaaaa: {:?}\n", err).as_bytes());
-						// assert_eq!(err, 0);
-						// StdErr.write_all(b"aaaaa\n");
-						// loop { }
-						if n == 1
-							&& pollfds[0]
-								.revents()
-								.unwrap()
-								.contains(poll::PollFlags::POLLHUP)
-						{
-							// (err,err2) == (Ok(0),Ok(0)) {
-							signal::kill(unistd::getpid(), signal::SIGKILL).unwrap();
-						}
-						// std::process::abort();
-						// loop {}
-						// });
-						ptr::null_mut()
-					}
-					let mut native: libc::pthread_t = 0;
-					let res = unsafe {
-						libc::pthread_create(
-							&mut native,
-							ptr::null(),
-							thread,
-							// ptr::null_mut(),
-							usize::try_from(pipe_read).unwrap() as _,
-						)
-					};
-					assert_eq!(res, 0);
-					// #[cfg(any(target_os = "android", target_os = "linux"))]
-					// {
-					// 	let err = unsafe {
-					// 		nix::libc::prctl(nix::libc::PR_SET_PDEATHSIG, nix::libc::SIGKILL)
-					// 	};
-					// 	assert_eq!(err, 0);
-					// }
-					ForkResult::Child
-				}
-				ForkResult::Parent(mut child) => {
-					unistd::close(pipe_read).unwrap();
-					child.owns = Some(Handle {
-						state: AtomicU8::new(0),
-						pipe_write,
-					});
-					// std::thread::sleep_ms(500);
-					// let group = Pid::from_raw(-child.pid.as_raw());
-					// signal::kill(group, signal::SIGKILL).expect("e");
-					// eprintln!("{}", format!("kill {}", group));
-					// let status = ChildHandle::wait_(group).expect("f");
-					// assert!(matches!(status, WaitStatus::Signaled(signal::SIGKILL, _)), "{:?}", status);
-					ForkResult::Parent(child)
-				}
-			})
-		}
+		let _ = may_outlive;
+		Ok(match unistd::fork()? {
+			unistd::ForkResult::Child => ForkResult::Child,
+			unistd::ForkResult::Parent { child } => ForkResult::Parent(ChildHandle {
+				pid: child,
+				owns: None,
+			}),
+		})
 	}
-}
-
-fn basic_fork() -> nix::Result<ForkResult> {
-	Ok(match unistd::fork()? {
-		unistd::ForkResult::Child => ForkResult::Child,
-		unistd::ForkResult::Parent { child } => ForkResult::Parent(ChildHandle {
-			pid: child,
-			owns: None,
-		}),
-	})
 }
 
 #[cfg(test)]

--- a/src/process.rs
+++ b/src/process.rs
@@ -189,7 +189,7 @@ pub enum ForkResult {
 /// ```no_run
 /// use palaver::process::*;
 ///
-/// match fork(false, true).unwrap() {
+/// match fork(false).unwrap() {
 ///     ForkResult::Parent(child_proc) => {
 ///         // do stuff
 ///         // you can access child_proc.pid on any platform

--- a/src/process.rs
+++ b/src/process.rs
@@ -320,7 +320,7 @@ pub fn fork(orphan: bool) -> nix::Result<ForkResult> {
 				drop(ready_write);
 				#[cfg(any(target_os = "macos", target_os = "ios"))]
 				let _ = std::thread::spawn(move || {
-					std::thread::sleep(std::time::Duration::from_millis(1000));
+					std::thread::sleep(std::time::Duration::from_millis(10));
 					unistd::close(eternal_write).unwrap();
 				});
 				#[cfg(not(any(target_os = "macos", target_os = "ios")))]

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -7,6 +7,10 @@ use nix::{libc, poll, sys::socket};
 #[cfg(unix)]
 use std::convert::TryInto;
 
+#[doc(inline)]
+#[cfg(unix)]
+pub use socket::{AddressFamily, SockProtocol, SockType};
+
 #[cfg(unix)]
 bitflags::bitflags! {
 	/// Akin to nix::sys::socket::SockFlag but avail cross-platform
@@ -17,10 +21,11 @@ bitflags::bitflags! {
 		const SOCK_CLOEXEC  = 0b0000_0010;
 	}
 }
+
 /// Falls back to non-atomic if SOCK_NONBLOCK/SOCK_CLOEXEC unavailable
 #[cfg(unix)]
-pub fn socket<T: Into<Option<socket::SockProtocol>>>(
-	domain: socket::AddressFamily, ty: socket::SockType, flags: SockFlag, protocol: T,
+pub fn socket<T: Into<Option<SockProtocol>>>(
+	domain: AddressFamily, ty: SockType, flags: SockFlag, protocol: T,
 ) -> nix::Result<Fd> {
 	let mut flags_ = socket::SockFlag::empty();
 	flags_ = flags_;
@@ -73,6 +78,7 @@ pub fn socket<T: Into<Option<socket::SockProtocol>>>(
 		fd
 	})
 }
+
 /// Like accept4, falls back to non-atomic accept
 #[cfg(unix)]
 pub fn accept(sockfd: Fd, flags: SockFlag) -> nix::Result<Fd> {

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -66,8 +66,9 @@ pub fn gettid() -> u64 {
 pub fn count() -> usize {
 	#[cfg(any(target_os = "android", target_os = "linux"))]
 	{
-		procinfo::pid::stat_self()
+		procfs::process::Process::myself()
 			.unwrap()
+			.stat
 			.num_threads
 			.try_into()
 			.unwrap()

--- a/tests/fork.rs
+++ b/tests/fork.rs
@@ -147,7 +147,6 @@ mod fork {
 				};
 				signal::kill(Pid::from_raw(-child.pid.as_raw()), signal).unwrap(); // or SIGHUP SIGINT SIGTERM
 				child.wait().unwrap();
-				mem::forget(child);
 			}
 		})
 	}

--- a/tests/fork.rs
+++ b/tests/fork.rs
@@ -1,167 +1,303 @@
-#![cfg(unix)]
-
-use nix::{sys::signal, unistd::Pid, *};
-use rand::Rng;
-use std::{
-	mem, process, sync::{
-		atomic::{AtomicBool, Ordering}, Arc
-	}, thread::{self, sleep}, time::Duration
-};
-
-use palaver::{
-	file::pipe, process::{fork, ForkResult}
-};
-
-fn kills_grandchild() {
-	let (read, write) = pipe(fcntl::OFlag::empty()).unwrap();
-	let child = if let ForkResult::Parent(child) = fork(false).unwrap() {
-		child
-	} else {
-		let _child = if let ForkResult::Parent(child) = fork(false).unwrap() {
-			child
-		} else {
-			let err = unistd::write(write, &[0]).unwrap();
-			assert_eq!(err, 1);
-			loop {
-				unistd::pause()
-			}
-		};
-		unistd::close(write).unwrap();
-		loop {
-			unistd::pause()
-		}
+#[cfg(unix)]
+mod fork {
+	use nix::{sys::signal, unistd::Pid, *};
+	use rand::{seq::SliceRandom, Rng};
+	use std::{
+		mem, process, sync::{
+			atomic::{AtomicBool, Ordering}, Arc
+		}, thread::{self, sleep}, time::Duration
 	};
-	unistd::close(write).unwrap();
-	let err = unistd::read(read, &mut [0]).unwrap();
-	assert_eq!(err, 1);
 
-	let mut flags =
-		fcntl::OFlag::from_bits_truncate(fcntl::fcntl(read, fcntl::FcntlArg::F_GETFL).unwrap());
-	flags |= fcntl::OFlag::O_NONBLOCK;
-	let err = fcntl::fcntl(read, fcntl::FcntlArg::F_SETFL(flags)).unwrap();
-	assert_eq!(err, 0);
-	let err = unistd::read(read, &mut [0]);
-	assert_eq!(err, Err(nix::Error::Sys(nix::errno::Errno::EAGAIN)));
-	flags &= !fcntl::OFlag::O_NONBLOCK;
-	let err = fcntl::fcntl(read, fcntl::FcntlArg::F_SETFL(flags)).unwrap();
-	assert_eq!(err, 0);
-
-	if rand::random() {
-		drop(child);
-	} else {
-		sys::signal::kill(child.pid, sys::signal::SIGKILL).unwrap();
-	}
-	let err = unistd::read(read, &mut [0]).unwrap();
-	assert_eq!(err, 0);
-	unistd::close(read).unwrap();
-}
-
-fn run(threads: usize, iterations: usize) {
-	let done = Arc::new(AtomicBool::new(false));
-	let done1 = done.clone();
-	let allocator = thread::spawn(move || {
-		let mut rng = rand::thread_rng();
-		while !done1.load(Ordering::Relaxed) {
-			let a = (0..rng.gen_range(0, 1000u16)).collect::<Vec<_>>();
-			sleep(rng.gen_range(Duration::new(0, 0), Duration::from_millis(1)));
-			drop(a); // std::hint::black_box when it's stable
-		}
-	});
-	let run = move |thread| {
-		for i in 0..iterations {
-			kills_grandchild();
-			if i % 100 == 0 {
-				println!("{}\t{}", thread, i);
-			}
-		}
+	use palaver::{
+		file::pipe, process::{fork, ForkResult}
 	};
-	let handles = (1..threads)
-		.map(|thread| thread::spawn(move || run(thread)))
-		.collect::<Vec<_>>();
-	run(0);
-	for handle in handles {
-		handle.join().unwrap();
-	}
-	done.store(true, Ordering::Relaxed);
-	allocator.join().unwrap();
-}
 
-fn multithreaded() {
-	assert_dead(|| {
-		let pid = unistd::getpid();
-		let group = unistd::getpgrp();
-		let as_group_leader = pid == group;
-		run(10, 10_000);
+	#[global_allocator]
+	static ALLOC: forbid_alloc::Alloc<std::alloc::System> =
+		forbid_alloc::Alloc::new(std::alloc::System);
 
-		if let ForkResult::Parent(child) = fork(false).unwrap() {
-			child.wait().unwrap();
-		} else {
-			assert_eq!(group, unistd::getpgrp());
-			if !as_group_leader {
-				unistd::setpgid(unistd::Pid::from_raw(0), unistd::Pid::from_raw(0)).unwrap();
-			}
-			run(10, 10_000);
-			process::exit(0);
-		}
-	})
-}
-
-fn group_kill() {
-	assert_dead(|| {
-		for _ in 0..1_000 {
+	fn kills_grandchild(signal: Option<sys::signal::Signal>) {
+		forbid_alloc(|| {
+			let (read, write) = pipe(fcntl::OFlag::empty()).unwrap();
 			let child = if let ForkResult::Parent(child) = fork(false).unwrap() {
 				child
 			} else {
-				unistd::setpgid(unistd::Pid::from_raw(0), unistd::Pid::from_raw(0)).unwrap();
-				if let ForkResult::Parent(child) = fork(false).unwrap() {
-					assert_eq!(unistd::getpid(), unistd::getpgrp());
-					mem::forget(child);
+				let _child = if let ForkResult::Parent(child) = fork(false).unwrap() {
+					child
 				} else {
-					assert_ne!(unistd::getpid(), unistd::getpgrp());
+					let err = unistd::write(write, &[0]).unwrap();
+					assert_eq!(err, 1);
+					loop {
+						unistd::pause()
+					}
+				};
+				unistd::close(write).unwrap();
+				loop {
+					unistd::pause()
 				}
-				run(3, 10_000);
-				process::exit(0);
 			};
+			unistd::close(write).unwrap();
+			let err = unistd::read(read, &mut [0]).unwrap();
+			assert_eq!(err, 1);
 
-			sleep(rand::thread_rng().gen_range(Duration::new(0, 0), Duration::from_millis(500)));
-			signal::kill(Pid::from_raw(-child.pid.as_raw()), signal::SIGKILL).unwrap();
-			child.wait().unwrap();
-			mem::forget(child);
+			let mut flags = fcntl::OFlag::from_bits_truncate(
+				fcntl::fcntl(read, fcntl::FcntlArg::F_GETFL).unwrap(),
+			);
+			flags |= fcntl::OFlag::O_NONBLOCK;
+			let err = fcntl::fcntl(read, fcntl::FcntlArg::F_SETFL(flags)).unwrap();
+			assert_eq!(err, 0);
+			let err = unistd::read(read, &mut [0]);
+			assert_eq!(err, Err(nix::Error::Sys(nix::errno::Errno::EAGAIN)));
+			flags &= !fcntl::OFlag::O_NONBLOCK;
+			let err = fcntl::fcntl(read, fcntl::FcntlArg::F_SETFL(flags)).unwrap();
+			assert_eq!(err, 0);
+
+			if let Some(signal) = signal {
+				sys::signal::kill(child.pid, signal).unwrap();
+			} else {
+				drop(child);
+			}
+			let err = unistd::read(read, &mut [0]).unwrap();
+			assert_eq!(err, 0);
+			unistd::close(read).unwrap();
+		})
+	}
+
+	fn run(threads: usize, iterations: usize) {
+		let done = Arc::new(AtomicBool::new(false));
+		let done1 = done.clone();
+		let allocator = thread::spawn(move || {
+			let mut rng = rand::thread_rng();
+			while !done1.load(Ordering::Relaxed) {
+				let a = (0..rng.gen_range(0, 1000u16)).collect::<Vec<_>>();
+				sleep(rng.gen_range(Duration::new(0, 0), Duration::from_millis(1)));
+				drop(a); // std::hint::black_box when it's stable
+			}
+		});
+		let run = move |thread| {
+			let mut rng = rand::thread_rng();
+			for i in 0..iterations {
+				let signal = *[Some(sys::signal::SIGKILL), Some(sys::signal::SIGTERM), None]
+					.choose(&mut rng)
+					.unwrap();
+				kills_grandchild(signal);
+				if i % 100 == 0 {
+					println!("{}\t{}", thread, i);
+				}
+			}
+		};
+		let handles = (1..threads)
+			.map(|thread| thread::spawn(move || run(thread)))
+			.collect::<Vec<_>>();
+		run(0);
+		for handle in handles {
+			handle.join().unwrap();
 		}
-	})
-}
+		done.store(true, Ordering::Relaxed);
+		allocator.join().unwrap();
+	}
 
-// Run sequentially to avoid overloading / messing up assert_dead
-#[test]
-fn tests() {
-	println!("kills_grandchild");
-	kills_grandchild();
-	println!("multithreaded");
-	multithreaded();
-	println!("group_kill");
-	group_kill();
-	println!("done");
-}
+	fn multithreaded() {
+		assert_dead(|| {
+			let pid = unistd::getpid();
+			let group = unistd::getpgrp();
+			let as_group_leader = pid == group;
+			run(10, 10_000);
 
-fn assert_dead<R>(f: impl FnOnce() -> R) -> R {
-	let tmpdir = (0..10)
-		.map(|_| rand::thread_rng().sample(rand::distributions::Alphanumeric))
-		.collect::<String>();
-	std::fs::create_dir(&tmpdir).unwrap();
-	std::env::set_current_dir(&tmpdir).unwrap();
-	let ret = f();
-	std::env::set_current_dir("..").unwrap();
-	let out = std::process::Command::new("lsof")
-		.arg(&tmpdir)
-		.output()
-		.expect("failed to execute process")
-		.stdout;
-	let of = out
-		.split(|&x| x == b'\n')
-		.skip(1)
-		.filter(|x| !x.is_empty())
-		.count();
-	std::fs::remove_dir(&tmpdir).unwrap();
-	assert_eq!(of, 0, "{}", String::from_utf8_lossy(&out));
-	ret
+			assert_eq!(palaver::thread::count(), 1);
+			if let ForkResult::Parent(child) = fork(false).unwrap() {
+				child.wait().unwrap();
+			} else {
+				assert_eq!(group, unistd::getpgrp());
+				if !as_group_leader {
+					unistd::setpgid(unistd::Pid::from_raw(0), unistd::Pid::from_raw(0)).unwrap();
+				}
+				run(10, 10_000);
+				process::exit(0);
+			}
+		})
+	}
+
+	fn group_kill() {
+		assert_dead(|| {
+			for _ in 0..1_000 {
+				assert_eq!(palaver::thread::count(), 1);
+				let child = if let ForkResult::Parent(child) = fork(false).unwrap() {
+					child
+				} else {
+					unistd::setpgid(unistd::Pid::from_raw(0), unistd::Pid::from_raw(0)).unwrap();
+					assert_eq!(palaver::thread::count(), 1);
+					if let ForkResult::Parent(child) = fork(false).unwrap() {
+						assert_eq!(unistd::getpid(), unistd::getpgrp());
+						mem::forget(child);
+					} else {
+						assert_ne!(unistd::getpid(), unistd::getpgrp());
+					}
+					run(3, 10_000);
+					process::exit(0);
+				};
+
+				sleep(
+					rand::thread_rng().gen_range(Duration::new(0, 0), Duration::from_millis(500)),
+				);
+				let signal = if rand::random() {
+					signal::SIGKILL
+				} else {
+					signal::SIGTERM
+				};
+				signal::kill(Pid::from_raw(-child.pid.as_raw()), signal).unwrap(); // or SIGHUP SIGINT SIGTERM
+				child.wait().unwrap();
+				mem::forget(child);
+			}
+		})
+	}
+
+	// We need precisely 1 thread, so we can't use #[test]
+	pub fn main() {
+		println!("multithreaded");
+		multithreaded();
+		println!("group_kill");
+		group_kill();
+		println!("done");
+	}
+
+	fn assert_dead<R>(f: impl FnOnce() -> R) -> R {
+		let tmpdir = (0..10)
+			.map(|_| rand::thread_rng().sample(rand::distributions::Alphanumeric))
+			.collect::<String>();
+		std::fs::create_dir(&tmpdir).unwrap();
+		std::env::set_current_dir(&tmpdir).unwrap();
+		let ret = f();
+		std::env::set_current_dir("..").unwrap();
+		let out = std::process::Command::new("lsof")
+			.arg(&tmpdir)
+			.output()
+			.expect("failed to execute process")
+			.stdout;
+		let of = out
+			.split(|&x| x == b'\n')
+			.skip(1)
+			.filter(|x| !x.is_empty())
+			.count();
+		std::fs::remove_dir(&tmpdir).unwrap();
+		assert_eq!(of, 0, "{}", String::from_utf8_lossy(&out));
+		ret
+	}
+
+	mod forbid_alloc {
+		use std::{
+			alloc::{GlobalAlloc, Layout}, cell::RefCell, fs::File, io::{self, Write}, os::unix::io::{FromRawFd, IntoRawFd}
+		};
+
+		#[derive(Copy, Clone, PartialEq)]
+		enum State {
+			Allowed,
+			Forbidden,
+			Panicking,
+		}
+
+		thread_local! {
+			static STATE: RefCell<State> = RefCell::new(State::Allowed);
+		}
+
+		pub struct Alloc<A> {
+			inner: A,
+		}
+		impl<A> Alloc<A> {
+			pub const fn new(inner: A) -> Self {
+				Self { inner }
+			}
+			fn panic() -> bool {
+				STATE.with(|alloc_forbid| {
+					let mut state = alloc_forbid.borrow_mut();
+					if *state != State::Panicking && std::thread::panicking() {
+						*state = State::Panicking;
+					}
+					let panic = *state == State::Forbidden;
+					if panic {
+						*state = State::Panicking;
+					}
+					panic
+				})
+			}
+		}
+		unsafe impl<A> GlobalAlloc for Alloc<A>
+		where
+			A: GlobalAlloc,
+		{
+			unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+				if Self::panic() {
+					StdErr
+						.write_all(b"alloc inside forbid_alloc: panicking!\n")
+						.unwrap();
+					panic!();
+				}
+				self.inner.alloc(layout)
+			}
+
+			unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+				if Self::panic() {
+					StdErr
+						.write_all(b"realloc inside forbid_alloc: panicking!\n")
+						.unwrap();
+					panic!();
+				}
+				self.inner.realloc(ptr, layout, new_size)
+			}
+
+			unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+				if Self::panic() {
+					StdErr
+						.write_all(b"dealloc inside forbid_alloc: panicking!\n")
+						.unwrap();
+					panic!();
+				}
+				self.inner.dealloc(ptr, layout)
+			}
+		}
+
+		pub fn forbid_alloc<R>(f: impl FnOnce() -> R) -> R {
+			let mut toggled = false;
+			STATE.with(|alloc_forbid| {
+				let mut state = alloc_forbid.borrow_mut();
+				if *state == State::Allowed {
+					*state = State::Forbidden;
+					toggled = true;
+				}
+			});
+			let ret = f();
+			if toggled {
+				STATE.with(|alloc_forbid| {
+					let mut state = alloc_forbid.borrow_mut();
+					if *state == State::Forbidden {
+						*state = State::Allowed;
+					}
+				});
+			}
+			ret
+		}
+
+		struct StdErr;
+		impl Write for StdErr {
+			fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+				let mut file = unsafe { File::from_raw_fd(libc::STDERR_FILENO) };
+				let ret = file.write(buf);
+				let _ = file.into_raw_fd();
+				ret
+			}
+			fn flush(&mut self) -> io::Result<()> {
+				Ok(())
+			}
+		}
+	}
+	use forbid_alloc::forbid_alloc;
+}
+#[cfg(windows)]
+mod fork {
+	pub fn main() {
+		println!("not implemented on windows");
+	}
+}
+fn main() {
+	fork::main();
 }

--- a/tests/fork.rs
+++ b/tests/fork.rs
@@ -131,7 +131,7 @@ fn group_kill() {
 	})
 }
 
-// Run sequentially
+// Run sequentially to avoid overloading / messing up assert_dead
 #[test]
 fn tests() {
 	println!("kills_grandchild");

--- a/tests/fork.rs
+++ b/tests/fork.rs
@@ -1,0 +1,117 @@
+#![cfg(unix)]
+
+use nix::*;
+use rand::Rng;
+use std::{
+	process, sync::{
+		atomic::{AtomicBool, Ordering}, Arc
+	}, thread::{self, sleep}, time::Duration
+};
+
+use palaver::{
+	file::pipe, process::{fork, ForkResult}
+};
+
+#[inline]
+fn abort_on_unwind<F: FnOnce() -> T, T>(f: F) -> T {
+	replace_with::on_unwind(f, || {
+		std::process::abort();
+	})
+}
+
+#[test]
+fn test_kills_grandchild() {
+	let (read, write) = pipe(fcntl::OFlag::empty()).unwrap();
+	let child = if let ForkResult::Parent(child) = fork(false, true).unwrap() {
+		child
+	} else {
+		let _child = if let ForkResult::Parent(child) = fork(false, true).unwrap() {
+			child
+		} else {
+			let err = unistd::write(write, &mut [0]).unwrap();
+			assert_eq!(err, 1);
+			loop {
+				unistd::pause()
+			}
+		};
+		unistd::close(write).unwrap();
+		loop {
+			unistd::pause()
+		}
+	};
+	unistd::close(write).unwrap();
+	let err = unistd::read(read, &mut [0]).unwrap();
+	assert_eq!(err, 1);
+
+	let mut flags =
+		fcntl::OFlag::from_bits_truncate(fcntl::fcntl(read, fcntl::FcntlArg::F_GETFL).unwrap());
+	flags |= fcntl::OFlag::O_NONBLOCK;
+	let err = fcntl::fcntl(read, fcntl::FcntlArg::F_SETFL(flags)).unwrap();
+	assert_eq!(err, 0);
+	let err = unistd::read(read, &mut [0]);
+	assert_eq!(err, Err(nix::Error::Sys(nix::errno::Errno::EAGAIN)));
+	flags &= !fcntl::OFlag::O_NONBLOCK;
+	let err = fcntl::fcntl(read, fcntl::FcntlArg::F_SETFL(flags)).unwrap();
+	assert_eq!(err, 0);
+
+	if rand::random() {
+		drop(child);
+	} else {
+		sys::signal::kill(child.pid, sys::signal::SIGKILL).unwrap();
+	}
+	let err = unistd::read(read, &mut [0]).unwrap();
+	assert_eq!(err, 0);
+	unistd::close(read).unwrap();
+}
+
+fn run(threads: usize, iterations: usize) {
+	let done = Arc::new(AtomicBool::new(false));
+	let done1 = done.clone();
+	thread::spawn(move || {
+		abort_on_unwind(|| {
+			let mut rng = rand::thread_rng();
+			while !done1.load(Ordering::Relaxed) {
+				let a = (0..rng.gen_range(0, 1000u16)).collect::<Vec<_>>();
+				sleep(rng.gen_range(Duration::new(0, 0), Duration::from_millis(1)));
+				drop(a); // std::hint::black_box when it's stable
+			}
+		})
+	});
+	let run = move |thread| {
+		for i in 0..iterations {
+			test_kills_grandchild();
+			if i % 100 == 0 {
+				println!("{}\t{}", thread, i);
+			}
+		}
+	};
+	let handles = (1..threads)
+		.map(|thread| thread::spawn(move || run(thread)))
+		.collect::<Vec<_>>();
+	run(0);
+	for handle in handles {
+		handle.join().unwrap();
+	}
+	done.store(true, Ordering::Relaxed);
+}
+
+#[test]
+fn main() {
+	abort_on_unwind(|| {
+		let pid = unistd::getpid();
+		let group = unistd::getpgrp();
+		let as_group_leader = pid == group;
+		run(10, 10_000);
+
+		if let ForkResult::Parent(child) = fork(false, true).unwrap() {
+			child.wait().unwrap();
+		} else {
+			assert_eq!(group, unistd::getpgrp());
+			if !as_group_leader {
+				unistd::setpgid(unistd::Pid::from_raw(0), unistd::Pid::from_raw(0)).unwrap();
+			}
+			run(10, 10_000);
+			process::exit(0);
+		}
+	})
+}

--- a/tests/fork.rs
+++ b/tests/fork.rs
@@ -22,13 +22,13 @@ fn abort_on_unwind<F: FnOnce() -> T, T>(f: F) -> T {
 #[test]
 fn test_kills_grandchild() {
 	let (read, write) = pipe(fcntl::OFlag::empty()).unwrap();
-	let child = if let ForkResult::Parent(child) = fork(false, true).unwrap() {
+	let child = if let ForkResult::Parent(child) = fork(false).unwrap() {
 		child
 	} else {
-		let _child = if let ForkResult::Parent(child) = fork(false, true).unwrap() {
+		let _child = if let ForkResult::Parent(child) = fork(false).unwrap() {
 			child
 		} else {
-			let err = unistd::write(write, &mut [0]).unwrap();
+			let err = unistd::write(write, &[0]).unwrap();
 			assert_eq!(err, 1);
 			loop {
 				unistd::pause()
@@ -103,7 +103,7 @@ fn main() {
 		let as_group_leader = pid == group;
 		run(10, 10_000);
 
-		if let ForkResult::Parent(child) = fork(false, true).unwrap() {
+		if let ForkResult::Parent(child) = fork(false).unwrap() {
 			child.wait().unwrap();
 		} else {
 			assert_eq!(group, unistd::getpgrp());


### PR DESCRIPTION
Implemented using process descriptors (pdfork) on FreeBSD and normal fork + an extra process elsewhere.

- immune to PID race conditions (see [here](https://lwn.net/Articles/773459/) for a description of the race);
- thus it's possible to `waitpid()` on one thread and `kill()` on another without a race;
- option to orphan a process, i.e. hand it off to init;
- child processes are killed on parent termination;
- and it works in the [Capsicum](https://wiki.freebsd.org/Capsicum) capability mode sandbox.
