### PR TITLE
Mitigate fexecve fallback leaking files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "palaver"
-version = "0.3.0-alpha.2"
+version = "0.3.0-alpha.3"
 license = "MIT OR Apache-2.0"
 authors = ["Alec Mocatta <alec@mocatta.net>"]
 categories = ["os::unix-apis","os::windows-apis","os::macos-apis"]
@@ -12,7 +12,7 @@ This library attempts to provide reliable polyfills for functionality that isn't
 """
 repository = "https://github.com/alecmocatta/palaver"
 homepage = "https://github.com/alecmocatta/palaver"
-documentation = "https://docs.rs/palaver/0.3.0-alpha.2"
+documentation = "https://docs.rs/palaver/0.3.0-alpha.3"
 readme = "README.md"
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ valgrind_request = { version = "1.1", optional = true }
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.47"
 nix = "0.16"
+twox-hash = { version = "1.5", default-features = false }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["processthreadsapi"] }

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![Crates.io](https://img.shields.io/crates/v/palaver.svg?maxAge=86400)](https://crates.io/crates/palaver)
 [![MIT / Apache 2.0 licensed](https://img.shields.io/crates/l/palaver.svg?maxAge=2592000)](#License)
-[![Build Status](https://dev.azure.com/alecmocatta/palaver/_apis/build/status/tests?branchName=master)](https://dev.azure.com/alecmocatta/palaver/_build/latest?branchName=master)
+[![Build Status](https://dev.azure.com/alecmocatta/palaver/_apis/build/status/tests?branchName=master)](https://dev.azure.com/alecmocatta/palaver/_build)
 
-[Docs](https://docs.rs/palaver/0.3.0-alpha.2)
+[Docs](https://docs.rs/palaver/0.3.0-alpha.3)
 
 Cross-platform polyfills.
 
@@ -16,41 +16,41 @@ This library attempts to provide reliable polyfills for functionality that isn't
 
 <table><!-- https://github.com/alecmocatta/palaver/new/master to preview changes -->
 <tr><th>Threading</th><th>Description</th><th>Linux</th><th>macOS</th><th>Windows</th><th>FreeBSD</th><th>NetBSD</th><th>iOS</th><th>Android</th></tr>
-<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.2/palaver/thread/fn.gettid.html"><code>gettid()</code><a></td><td>Get thread ID</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
-<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.2/palaver/thread/fn.count.html"><code>count()</code></a></td><td>Number of threads in current process</td><td>✓</td><td>✓</td><td> </td><td> </td><td> </td><td>✓</td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.3/palaver/thread/fn.gettid.html"><code>gettid()</code><a></td><td>Get thread ID</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.3/palaver/thread/fn.count.html"><code>count()</code></a></td><td>Number of threads in current process</td><td>✓</td><td>✓</td><td> </td><td> </td><td> </td><td>✓</td><td>✓</td></tr>
 <tr><th>Files</th><th>Description</th><th>Linux</th><th>macOS</th><th>Windows</th><th>FreeBSD</th><th>NetBSD</th><th>iOS</th><th>Android</th></tr>
-<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.2/palaver/file/fn.seal_fd.html"><code>seal_fd()</code></a></td><td>Make a file descriptor read-only</td><td>✓</td><td>✓</td><td> </td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
-<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.2/palaver/file/fn.dup_fd.html"><code>dup_fd()</code></a></td><td>Duplicate a file descriptor</td><td>✓</td><td>✓</td><td> </td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
-<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.2/palaver/file/fn.copy_fd.html"><code>copy_fd()</code></a></td><td>Copy a file descriptor to a specific offset</td><td>✓</td><td>✓</td><td>–</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
-<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.2/palaver/file/fn.move_fd.html"><code>move_fd()</code></a></td><td>Move a file descriptor to a specific offset</td><td>✓</td><td>✓</td><td>–</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
-<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.2/palaver/file/fn.move_fds.html"><code>move_fds()</code></a></td><td>Move file descriptors to specific offsets</td><td>✓</td><td>✓</td><td>–</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
-<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.2/palaver/file/fn.fd_dir.html"><code>fd_dir()</code></a></td><td>Get a path to the file descriptor directory</td><td>✓</td><td>✓</td><td>–</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
-<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.2/palaver/file/fn.fd_path.html"><code>fd_path()</code></a></td><td>Get a path to a file descriptor</td><td>✓</td><td>✓</td><td>–</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
-<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.2/palaver/file/struct.FdIter.html"><code>FdIter</code></a></td><td>Iterate all open file descriptors</td><td>✓</td><td>✓</td><td> </td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
-<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.2/palaver/file/fn.memfd_create.html"><code>memfd_create()</code></a></td><td>Create an anonymous file</td><td>✓</td><td>✓</td><td> </td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
-<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.2/palaver/file/fn.fexecve.html"><code>fexecve()</code></a></td><td>Execute program specified via file descriptor</td><td>✓</td><td>✓</td><td> </td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
-<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.2/palaver/file/fn.copy.html"><code>copy()</code></a></td><td>Copy by looping <code>io::copy</code></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
-<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.2/palaver/file/fn.copy_sendfile.html"><code>copy_sendfile()</code></a></td><td>Copy using <code>sendfile</code></td><td>✓</td><td>✓</td><td> </td><td>✓</td><td> </td><td>✓</td><td>✓</td></tr>
-<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.2/palaver/file/fn.copy_splice.html"><code>copy_splice()</code></a></td><td>Copy using <code>splice</code></td><td>✓</td><td> </td><td> </td><td> </td><td> </td><td> </td><td>✓</td></tr>
-<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.2/palaver/file/fn.pipe.html"><code>pipe()</code></a></td><td>Create a pipe</td><td>✓</td><td>✓</td><td> </td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.3/palaver/file/fn.seal_fd.html"><code>seal_fd()</code></a></td><td>Make a file descriptor read-only</td><td>✓</td><td>✓</td><td> </td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.3/palaver/file/fn.dup_fd.html"><code>dup_fd()</code></a></td><td>Duplicate a file descriptor</td><td>✓</td><td>✓</td><td> </td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.3/palaver/file/fn.copy_fd.html"><code>copy_fd()</code></a></td><td>Copy a file descriptor to a specific offset</td><td>✓</td><td>✓</td><td>–</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.3/palaver/file/fn.move_fd.html"><code>move_fd()</code></a></td><td>Move a file descriptor to a specific offset</td><td>✓</td><td>✓</td><td>–</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.3/palaver/file/fn.move_fds.html"><code>move_fds()</code></a></td><td>Move file descriptors to specific offsets</td><td>✓</td><td>✓</td><td>–</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.3/palaver/file/fn.fd_dir.html"><code>fd_dir()</code></a></td><td>Get a path to the file descriptor directory</td><td>✓</td><td>✓</td><td>–</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.3/palaver/file/fn.fd_path.html"><code>fd_path()</code></a></td><td>Get a path to a file descriptor</td><td>✓</td><td>✓</td><td>–</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.3/palaver/file/struct.FdIter.html"><code>FdIter</code></a></td><td>Iterate all open file descriptors</td><td>✓</td><td>✓</td><td> </td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.3/palaver/file/fn.memfd_create.html"><code>memfd_create()</code></a></td><td>Create an anonymous file</td><td>✓</td><td>✓</td><td> </td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.3/palaver/file/fn.fexecve.html"><code>fexecve()</code></a></td><td>Execute program specified via file descriptor</td><td>✓</td><td>✓</td><td> </td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.3/palaver/file/fn.copy.html"><code>copy()</code></a></td><td>Copy by looping <code>io::copy</code></td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.3/palaver/file/fn.copy_sendfile.html"><code>copy_sendfile()</code></a></td><td>Copy using <code>sendfile</code></td><td>✓</td><td>✓</td><td> </td><td>✓</td><td> </td><td>✓</td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.3/palaver/file/fn.copy_splice.html"><code>copy_splice()</code></a></td><td>Copy using <code>splice</code></td><td>✓</td><td> </td><td> </td><td> </td><td> </td><td> </td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.3/palaver/file/fn.pipe.html"><code>pipe()</code></a></td><td>Create a pipe</td><td>✓</td><td>✓</td><td> </td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
 <tr><th>Socket</th><th>Description</th><th>Linux</th><th>macOS</th><th>Windows</th><th>FreeBSD</th><th>NetBSD</th><th>iOS</th><th>Android</th></tr>
-<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.2/palaver/socket/fn.socket.html"><code>socket()</code></a></td><td>Create a socket</td><td>✓</td><td>✓</td><td> </td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
-<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.2/palaver/socket/fn.accept.html"><code>accept()</code></a></td><td>Accept a connection on a socket</td><td>✓</td><td>✓</td><td> </td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
-<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.2/palaver/socket/fn.is_connected.html"><code>is_connected()</code></a></td><td>Get whether a pending connection is connected</td><td>✓</td><td>✓</td><td> </td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
-<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.2/palaver/socket/fn.unreceived.html"><code>unreceived()</code></a></td><td>Get number of bytes readable</td><td>✓</td><td>✓</td><td> </td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
-<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.2/palaver/socket/fn.unsent.html"><code>unsent()</code></a></td><td>Get number of bytes that have yet to be acknowledged</td><td>✓</td><td>✓</td><td> </td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.3/palaver/socket/fn.socket.html"><code>socket()</code></a></td><td>Create a socket</td><td>✓</td><td>✓</td><td> </td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.3/palaver/socket/fn.accept.html"><code>accept()</code></a></td><td>Accept a connection on a socket</td><td>✓</td><td>✓</td><td> </td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.3/palaver/socket/fn.is_connected.html"><code>is_connected()</code></a></td><td>Get whether a pending connection is connected</td><td>✓</td><td>✓</td><td> </td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.3/palaver/socket/fn.unreceived.html"><code>unreceived()</code></a></td><td>Get number of bytes readable</td><td>✓</td><td>✓</td><td> </td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.3/palaver/socket/fn.unsent.html"><code>unsent()</code></a></td><td>Get number of bytes that have yet to be acknowledged</td><td>✓</td><td>✓</td><td> </td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
 <tr><th>Env</th><th>Description</th><th>Linux</th><th>macOS</th><th>Windows</th><th>FreeBSD</th><th>NetBSD</th><th>iOS</th><th>Android</th></tr>
-<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.2/palaver/env/fn.exe.html"><code>exe()</code></a></td><td>Opens the current running executable</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
-<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.2/palaver/env/fn.exe_path.html"><code>exe_path()</code></a></td><td>Get a path to the current running executable</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
-<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.2/palaver/env/fn.args.html"><code>args()</code></a></td><td>Get command line arguments</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
-<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.2/palaver/env/fn.vars.html"><code>vars()</code></a></td><td>Get environment variables</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.3/palaver/env/fn.exe.html"><code>exe()</code></a></td><td>Opens the current running executable</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.3/palaver/env/fn.exe_path.html"><code>exe_path()</code></a></td><td>Get a path to the current running executable</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.3/palaver/env/fn.args.html"><code>args()</code></a></td><td>Get command line arguments</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.3/palaver/env/fn.vars.html"><code>vars()</code></a></td><td>Get environment variables</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
 <tr><th>Process</th><th>Description</th><th>Linux</th><th>macOS</th><th>Windows</th><th>FreeBSD</th><th>NetBSD</th><th>iOS</th><th>Android</th></tr>
-<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.2/palaver/process/fn.count.html"><code>count()</code></a></td><td>Count the processes visible to the current process</td><td>✓</td><td>✓</td><td>–</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
-<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.2/palaver/process/fn.count_threads.html"><code>count_threads()</code></a></td><td>Count the threads visible to the current process</td><td>✓</td><td>✓</td><td>–</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
-<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.2/palaver/process/fn.fork.html"><code>fork()</code></a></td><td>Fork a process, using process descriptors where available</td><td>✓</td><td>✓</td><td>–</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.3/palaver/process/fn.count.html"><code>count()</code></a></td><td>Count the processes visible to the current process</td><td>✓</td><td>✓</td><td>–</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.3/palaver/process/fn.count_threads.html"><code>count_threads()</code></a></td><td>Count the threads visible to the current process</td><td>✓</td><td>✓</td><td>–</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.3/palaver/process/fn.fork.html"><code>fork()</code></a></td><td>Fork a process, using process descriptors where available</td><td>✓</td><td>✓</td><td>–</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
 <tr><th>Valgrind</th><th>Description</th><th>Linux</th><th>macOS</th><th>Windows</th><th>FreeBSD</th><th>NetBSD</th><th>iOS</th><th>Android</th></tr>
-<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.2/palaver/valgrind/fn.is.html"><code>is()</code></a></td><td>Check if running under Valgrind</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
-<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.2/palaver/valgrind/fn.start_fd.html"><code>start_fd()</code></a></td><td>Get Valgrind's file descriptor range</td><td>✓</td><td>✓</td><td>–</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.3/palaver/valgrind/fn.is.html"><code>is()</code></a></td><td>Check if running under Valgrind</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
+<tr><td><a href="https://docs.rs/palaver/0.3.0-alpha.3/palaver/valgrind/fn.start_fd.html"><code>start_fd()</code></a></td><td>Get Valgrind's file descriptor range</td><td>✓</td><td>✓</td><td>–</td><td>✓</td><td>✓</td><td>✓</td><td>✓</td></tr>
 </table>
 
 ## License

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 //!
 //! `palaver` = "Platform Abstraction Layer" + pa·lav·er *n.* prolonged and tedious fuss.
 
-#![doc(html_root_url = "https://docs.rs/palaver/0.3.0-alpha.2")]
+#![doc(html_root_url = "https://docs.rs/palaver/0.3.0-alpha.3")]
 #![warn(
 	missing_copy_implementations,
 	missing_debug_implementations,


### PR DESCRIPTION
Make the `fexecve` fallback use a hash of the contents as the filename, to mitigate leaking a file per call. Now, leaks a file per distinct binary `fexecve` executes.