### PR TITLE
Bump lint toolchain

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ jobs:
     endpoint: alecmocatta
     default:
       rust_toolchain: stable nightly
-      rust_lint_toolchain: nightly-2020-01-25
+      rust_lint_toolchain: nightly-2020-07-01
       rust_flags: ''
       rust_features: ''
       rust_target_check: ''

--- a/src/file.rs
+++ b/src/file.rs
@@ -317,7 +317,7 @@ pub fn fexecve(fd: Fd, args: &[&CStr], vars: &[&CStr]) -> nix::Result<Infallible
 		target_os = "solaris"
 	))]
 	{
-		res = res.or_else(|_| {
+		res = res.map_err(|_| {
 			let args: heapless::Vec<*const libc::c_char, heapless::consts::U256> = args
 				.iter()
 				.map(|arg| arg.as_ptr())
@@ -331,7 +331,7 @@ pub fn fexecve(fd: Fd, args: &[&CStr], vars: &[&CStr]) -> nix::Result<Infallible
 
 			let _ = unsafe { libc::fexecve(fd, args.as_ptr(), vars.as_ptr()) };
 
-			Err(nix::Error::Sys(nix::errno::Errno::last()))
+			nix::Error::Sys(nix::errno::Errno::last())
 		});
 	}
 	if res == Err(nix::Error::Sys(nix::errno::Errno::ENOSYS)) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,9 @@
 	clippy::must_use_candidate,
 	clippy::same_functions_in_if_condition,
 	clippy::shadow_unrelated,
-	clippy::similar_names
+	clippy::similar_names,
+	clippy::wildcard_imports,
+	clippy::match_single_binding
 )]
 
 pub mod env;


### PR DESCRIPTION
This bumps the rustc version used for linting above the MSRV of `bitflags` dep.